### PR TITLE
Adds a table3 parser

### DIFF
--- a/table3/111_148.htm
+++ b/table3/111_148.htm
@@ -1,0 +1,18815 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=8" />
+        <meta http-equiv="pragma" content="no-cache" /><!-- HTTP 1.0 -->
+        <meta http-equiv="cache-control" content="no-cache,must-revalidate" /><!-- HTTP 1.1 -->
+        <meta http-equiv="expires" content="0" />
+        <link rel="shortcut icon" href="/javax.faces.resource/favicon.ico.xhtml?ln=images" /><link type="text/css" rel="stylesheet" href="/javax.faces.resource/cssLayout.css.xhtml?ln=css" /><script type="text/javascript" src="/javax.faces.resource/jsf.js.xhtml?ln=javax.faces"></script><link type="text/css" rel="stylesheet" href="/javax.faces.resource/static.css.xhtml?ln=css" /></head><body><script type="text/javascript" src="/javax.faces.resource/browserPreferences.js.xhtml?ln=scripts"></script>
+        <div id="body">
+    <noscript>
+        <div style="font-size: 12px; font-family: Arial; background-color: #F0F0FE;">
+            This page is better viewed with a JavaScript enabled browser.
+        </div>
+    </noscript>
+    <div id="header"><a href="/browse.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/u4.png.xhtml?ln=images" alt="OLRC home" style="border: none;" /></a>
+    </div>
+            <div style="margin-left: 2px; clear: both;  background-color: rgb(201, 173, 109);"><div id="menu_homeLink">
+        <div style="float:right;             width: 55px; height: 18px; font-family: Arial; margin-top: -20px;             text-align: center; cursor: pointer; background-color: rgb(187, 154, 74);             opacity: .9;             -ms-filter:'progid:DXImageTransform.Microsoft.Alpha(Opacity=90)';             filter: alpha(opacity=90);"><a href="/browse.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959" style="text-decoration: none; font-family: 'Calibri'; color: rgb(69, 38, 35); font-size: 15px; font-weight: bold;">
+                    Home</a>
+        </div></div>
+    <div id="menu"><script type="text/javascript" src="/javax.faces.resource/menu.js.xhtml?ln=scripts"></script>
+        <div id="subMenu">
+
+        <div id="item_SEARCH_BROWSE" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_SEARCH_BROWSE" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_SEARCH_BROWSE" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Search &amp; Browse
+                </span>
+            </div><a href="/browse.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_CURRENCY" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_CURRENCY" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_CURRENCY" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Currency and Updating
+                </span>
+            </div><a href="/currency/currency.shtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_CLASSIFICATION_TABLES" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_CLASSIFICATION_TABLES" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_CLASSIFICATION_TABLES" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Classification Tables
+                </span>
+            </div><a href="/classification/tables.shtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_POPULAR_NAME_TOOL" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_POPULAR_NAME_TOOL" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_POPULAR_NAME_TOOL" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Popular Name Tool
+                </span>
+            </div><a href="/popularnames/popularnames.htm;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_OTHER_TABLES_TOOLS" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_OTHER_TABLES_TOOLS" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_OTHER_TABLES_TOOLS" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Other Tables and Tools
+                </span>
+            </div><a href="#.xhtml"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_CITE_CHECKER" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_CITE_CHECKER" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_CITE_CHECKER" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Cite Checker
+                </span>
+            </div><a href="/cite.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_TABLEIII" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_TABLEIII" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u29.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_TABLEIII" style="font-family: 'Calibri'; color: rgb(0, 0, 0); font-size: 15px; font-weight: bold;">
+                    Table III - Statutes at Large
+                </span>
+            </div><a href="/table3/table3years.htm;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_OTHER_TABLES" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_OTHER_TABLES" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_OTHER_TABLES" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Other Tables
+                </span>
+            </div><a href="/tables/usctable1.htm;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_UNDERSTANTING" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_UNDERSTANTING" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_UNDERSTANTING" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Understanding the Code
+                </span>
+            </div><a href="#.xhtml"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_ABOUT_CODE" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_ABOUT_CODE" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_ABOUT_CODE" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    About the Code and Website
+                </span>
+            </div><a href="/about_code.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_ABOUT_CLASSIFICATION" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_ABOUT_CLASSIFICATION" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_ABOUT_CLASSIFICATION" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    About Classification
+                </span>
+            </div><a href="/about_classification.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_DETAILED_GUIDE" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_DETAILED_GUIDE" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_DETAILED_GUIDE" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Detailed Guide to the Code
+                </span>
+            </div><a href="/detailed_guide.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_FAQ" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_FAQ" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_FAQ" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    FAQ and Glossary
+                </span>
+            </div><a href="/faq.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_POSITIVE_LAW" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_POSITIVE_LAW" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_POSITIVE_LAW" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Positive Law Codification
+                </span>
+            </div><a href="/codification/legislation.shtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_EDITORIAL_RECLASSIFICATION" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_EDITORIAL_RECLASSIFICATION" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_EDITORIAL_RECLASSIFICATION" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Editorial Reclassification
+                </span>
+            </div><a href="/editorialreclassification/reclassification.html;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_DOWNLOADS" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_DOWNLOADS" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_DOWNLOADS" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    Downloads
+                </span>
+            </div><a href="/download/download.shtml;jsessionid=629C2B019419362DC648DD591D4BD959"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_THOMAS" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_THOMAS" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_THOMAS" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    THOMAS
+                </span>
+            </div><a href="http://thomas.loc.gov/" target="_new"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+
+        <div id="item_FDSYS" style="position: relative; top: 0px; left: 0px; width: 100%; height: 31px; overflow: visible;">
+            <span id="item_FDSYS" style="width: 100%; height: 31px;"><img src="/javax.faces.resource/u6.png.xhtml?ln=images" style="width: 100%; height: 31px;" />
+            </span>
+            <div style="position: absolute; left: 16px; top: 6px; width: 100%; height: 18px; font-family: Arial; text-align: left; word-wrap: break-word; cursor: pointer;">
+                <span id="text_FDSYS" style="font-family: 'Calibri'; color: rgb(49, 28, 26); font-size: 15px; font-weight: bold;">
+                    FDsys
+                </span>
+            </div><a href="http://www.gpo.gov/fdsys/"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a><a href="http://www.gpo.gov/fdsys/" target="_new"><img src="/javax.faces.resource/transparent.gif.xhtml?ln=images" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 31px; cursor: pointer; border: none;" /></a>
+        </div>
+        <script type="text/javascript"><!--
+           menu_init('TABLEIII');
+        --></script>
+    </div>
+</div>
+                <div id="content" class="page_content">
+                    <div class="page_content_internal"><head><title>TABLE III TOOL</title></head>
+
+
+
+<script language='JavaScript'>
+ <!-- 
+  var submittedCriteria = "";
+
+ function loadContent(){ 
+   submittedCriteria = window.document.selectionform.documentcriteria.value;
+   var reYear=/^\d{4}$/;
+   var reCongress=/^\d{1,}[th|d|st]/;
+   var reStatVol=/^\d{1,}$/;
+   if(submittedCriteria.search(reYear) > -1){
+    location.href="year" + submittedCriteria + ".htm";
+   }
+   else if(submittedCriteria.search(reCongress) > -1){
+    location.href="congress" + submittedCriteria + ".htm";
+   }
+   else if(submittedCriteria.search(reStatVol) > -1){
+    location.href="statutesatlargevolume" + submittedCriteria + ".htm";
+   }
+   else{
+    location.href=getActFileName(); 
+   }
+ }
+ 
+ function getActFileName(){
+   var fileName = submittedCriteria.replace("-", "_");
+   fileName = fileName.replace(":","_");
+   fileName = fileName.replace(/ /g,"");
+   fileName = fileName.replace(/\./g,"");
+   fileName = fileName + ".htm";
+   return(fileName);
+   }
+  
+  function disableEnterKey(e){
+   var key;
+   if(window.event)
+    key = window.event.keyCode; //IE
+   else
+    key = e.which; //firefox
+   if(key == 13){
+     loadContent();
+   }
+   return (key != 13);
+  }
+ 
+ function setinput(){
+    var temp = document.title;
+    temp = temp.replace("United States Code Table III: ", "");
+    document.selectionform.documentcriteria.value = temp;
+   }
+   -->
+   </script>
+
+
+
+ <div class='lrclogo'>
+
+  <img src="lawrevcnsl.gif" alt="Law Revision Counsel Logo" height='72' width='360'/>
+
+ </div>
+
+
+
+
+
+ <div class='lrcmenu'>
+
+  <p class='lrcmenulink' id='home'><a href="http://uscode.house.gov" id='home'>Home</a></p>
+
+  <p class='lrcmenulink' id='search'><a href="http://uscode.house.gov/search/criteria.shtml" id='search'>Search</a></p>
+
+  <p class='lrcmenulink' id='uscprelim'><a href="http://uscode.house.gov/uscprelim/uscprelim.shtml" id='search'>USCprelim</a></p>
+
+  <p class='lrcmenulink' id='download'><a href="http://uscode.house.gov/download/download.shtml" id='download'>Download</a></p>
+
+  <p class='lrcmenulink' id='classification'><a href="http://uscode.house.gov/classification/tables.shtml" id='updates'>Classification</a></p>
+
+  <p class='lrcmenulink' id='codification'><a href="http://uscode.house.gov/codification/legislation.shtml" id='codification'>Codification</a></p>
+
+  <p class='lrcmenulink' id='popnames'><a href="http://uscode.house.gov/popularnames/popularnames.htm" id='popnames'>Popular Names</a></p>
+
+  <p class='lrcmenulink' id='table3'><a href="http://uscode.house.gov/table3/table3years.htm" id='table3'>Table III</a></p>
+
+  <p class='lrcmenulink' id='othertables'><a href="http://uscode.house.gov/tables/usctable1.htm" id='othertables'>Other Tables</a></p>
+
+  <p class='lrcmenulink' id='about'><a href="http://uscode.house.gov/about/info.shtml" id='about'>About</a></p>
+
+  <p class='lrcmenulink' id='about'><a href="http://uscode.house.gov/about/currency.shtml" id='currency'>Currency</a></p>
+
+ </div>
+
+
+
+ <div class='inputarea'>
+
+   <form name='selectionform' onsubmit='loadContent()'>
+
+       <input type='text'  size='15' name='documentcriteria' onKeyPress='return disableEnterKey(event)'/><br/>
+
+       <input type='button' value='Get Document' name='getdoc' onclick='loadContent()'/>
+
+   </form>
+
+ </div>
+
+  <div class='headings'>
+
+  <h1 class='usc-title-head'>Table III Tool</h1>
+
+   <p class='table-description'>The Table III Tool enables you to browse the United States Code Table III. For printing purposes, the <a href='table3.pdf' class='inline'>PDF file</a> is recommended. A detailed explanation of the Table is located <a href='table3explanation.htm' class='inline'>here.</a>
+
+  </p>
+
+ </div>
+
+
+
+<!-- headerplaceholder -->
+
+ <div class="documentlevel">
+
+<table class='table3act'>
+
+<!-- field-start:documentcontext -->
+
+ <caption class='documentcontext'>
+
+  <span class='congress'><a class='header' href='congress111th.htm'>111th Cong.</a> <a class='t3topcongressesview' href='table3congresses.htm'>&nbsp;&uarr;&nbsp;</a></span>
+
+  <span class='statutesatlargevolume'><a class='header' href='statutesatlargevolume124.htm'>124   Stat.</a> <a class='t3topstatutesatlargevolumeview' href='table3statutesatlargevolumes.htm'>&nbsp;&uarr;&nbsp;</a></span>
+
+  <span class='textdate'>Mar. 23, <a class='header' href='year2010.htm'>2010</a> <a class='t3topyearsview' href='table3years.htm'>&nbsp;&uarr;&nbsp;</a></span>
+
+  <span class='prioract'><a class='header' href="111_147.htm">111&ndash;147</a></span>
+
+  <span class='act'>111&ndash;148</span>
+
+  <span class='nextact'><a class='header' href="111_149.htm">111&ndash;149</a></span>
+
+ </caption>
+
+<!-- field-end:documentcontext -->
+
+ <tr>
+
+  <th class='actsection' rowspan='2'>Act Section</th>
+
+  <th class='statutesatlargepage' rowspan='2'>Stat. Pg.</th>
+
+  <th class='unitedstatescode' colspan='3'>United States Code</th>
+
+ </tr>
+
+ <tr>
+
+  <th class='unitedstatescodetitle'>Title</th>
+
+  <th class='unitedstatescodesection'>Section</th>
+
+  <th class='unitedstatescodestatus'>Status</th>
+
+ </tr>
+
+<!-- field-start:documentdata -->
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1(a)</td>
+
+  <td class='statutesatlargepage'>119</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18001&num=0&edition=prelim>18001 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(2)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-25&num=0&edition=prelim>300gg&ndash;25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(2)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-26&num=0&edition=prelim>300gg&ndash;26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(2)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-27&num=0&edition=prelim>300gg&ndash;27</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(2)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-28&num=0&edition=prelim>300gg&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(3)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-9&num=0&edition=prelim>300gg&ndash;9</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(3)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-11&num=0&edition=prelim>300gg&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(3)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-12&num=0&edition=prelim>300gg&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(4)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-21&num=0&edition=prelim>300gg&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(4)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-22&num=0&edition=prelim>300gg&ndash;22</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(4)</td>
+
+  <td class='statutesatlargepage'>130</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-23&num=0&edition=prelim>300gg&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>131</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-11&num=0&edition=prelim>300gg&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>131</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-12&num=0&edition=prelim>300gg&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>131</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-13&num=0&edition=prelim>300gg&ndash;13</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>132</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-14&num=0&edition=prelim>300gg&ndash;14</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>132</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-15&num=0&edition=prelim>300gg&ndash;15</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>135</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-16&num=0&edition=prelim>300gg&ndash;16</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>135</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-17&num=0&edition=prelim>300gg&ndash;17</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>136</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-18&num=0&edition=prelim>300gg&ndash;18</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1001(5)</td>
+
+  <td class='statutesatlargepage'>137</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-19&num=0&edition=prelim>300gg&ndash;19</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1002</td>
+
+  <td class='statutesatlargepage'>138</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-93&num=0&edition=prelim>300gg&ndash;93</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1003</td>
+
+  <td class='statutesatlargepage'>139</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-94&num=0&edition=prelim>300gg&ndash;94</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1004</td>
+
+  <td class='statutesatlargepage'>140</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-11&num=0&edition=prelim>300gg&ndash;11 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1101</td>
+
+  <td class='statutesatlargepage'>141</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18001&num=0&edition=prelim>18001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1102</td>
+
+  <td class='statutesatlargepage'>143</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18002&num=0&edition=prelim>18002</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1103</td>
+
+  <td class='statutesatlargepage'>146</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18003&num=0&edition=prelim>18003</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1104(a)</td>
+
+  <td class='statutesatlargepage'>146</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d&num=0&edition=prelim>1320d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1104(b)(1)</td>
+
+  <td class='statutesatlargepage'>146</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d&num=0&edition=prelim>1320d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1104(b)(2)</td>
+
+  <td class='statutesatlargepage'>147</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d-2&num=0&edition=prelim>1320d&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1104(c)</td>
+
+  <td class='statutesatlargepage'>153</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d-2&num=0&edition=prelim>1320d&ndash;2 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1104(d)</td>
+
+  <td class='statutesatlargepage'>153</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395y&num=0&edition=prelim>1395y</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1105</td>
+
+  <td class='statutesatlargepage'>154</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d&num=0&edition=prelim>1320d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1201(2)</td>
+
+  <td class='statutesatlargepage'>154</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-3&num=0&edition=prelim>300gg&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1201(3)</td>
+
+  <td class='statutesatlargepage'>154</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-1&num=0&edition=prelim>300gg&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1201(3)</td>
+
+  <td class='statutesatlargepage'>154</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-4&num=0&edition=prelim>300gg&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>155</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg&num=0&edition=prelim>300gg</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>156</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-1&num=0&edition=prelim>300gg&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>156</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-2&num=0&edition=prelim>300gg&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>156</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-4&num=0&edition=prelim>300gg&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>160</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-5&num=0&edition=prelim>300gg&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>161</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-6&num=0&edition=prelim>300gg&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1201(4)</td>
+
+  <td class='statutesatlargepage'>161</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-7&num=0&edition=prelim>300gg&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1251</td>
+
+  <td class='statutesatlargepage'>161</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18011&num=0&edition=prelim>18011</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1252</td>
+
+  <td class='statutesatlargepage'>162</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18012&num=0&edition=prelim>18012</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1253</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18013&num=0&edition=prelim>18013</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1255</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg&num=0&edition=prelim>300gg nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1301</td>
+
+  <td class='statutesatlargepage'>162</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18021&num=0&edition=prelim>18021</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1302</td>
+
+  <td class='statutesatlargepage'>163</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18022&num=0&edition=prelim>18022</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1303</td>
+
+  <td class='statutesatlargepage'>168</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18023&num=0&edition=prelim>18023</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1304</td>
+
+  <td class='statutesatlargepage'>171</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18024&num=0&edition=prelim>18024</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1311</td>
+
+  <td class='statutesatlargepage'>173</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18031&num=0&edition=prelim>18031</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1312</td>
+
+  <td class='statutesatlargepage'>182</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18032&num=0&edition=prelim>18032</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1313</td>
+
+  <td class='statutesatlargepage'>184</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18033&num=0&edition=prelim>18033</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1321</td>
+
+  <td class='statutesatlargepage'>186</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18041&num=0&edition=prelim>18041</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1322</td>
+
+  <td class='statutesatlargepage'>187</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18042&num=0&edition=prelim>18042</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1322(h)(1)</td>
+
+  <td class='statutesatlargepage'>191</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1322(h)(2)</td>
+
+  <td class='statutesatlargepage'>192</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6033&num=0&edition=prelim>6033</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1322(h)(3)</td>
+
+  <td class='statutesatlargepage'>192</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4958&num=0&edition=prelim>4958</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1323</td>
+
+  <td class='statutesatlargepage'>192</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>18043</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1323</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18043&num=0&edition=prelim>18043</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1324</td>
+
+  <td class='statutesatlargepage'>199</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18044&num=0&edition=prelim>18044</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1331</td>
+
+  <td class='statutesatlargepage'>199</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18051&num=0&edition=prelim>18051</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1332</td>
+
+  <td class='statutesatlargepage'>203</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18052&num=0&edition=prelim>18052</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1333</td>
+
+  <td class='statutesatlargepage'>206</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18053&num=0&edition=prelim>18053</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1334</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18054&num=0&edition=prelim>18054</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1341</td>
+
+  <td class='statutesatlargepage'>208</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18061&num=0&edition=prelim>18061</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1342</td>
+
+  <td class='statutesatlargepage'>211</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18062&num=0&edition=prelim>18062</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1343</td>
+
+  <td class='statutesatlargepage'>212</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18063&num=0&edition=prelim>18063</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1401(a)</td>
+
+  <td class='statutesatlargepage'>213</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section36B&num=0&edition=prelim>36B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1401(b)</td>
+
+  <td class='statutesatlargepage'>219</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section280C&num=0&edition=prelim>280C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1401(d)(1)</td>
+
+  <td class='statutesatlargepage'>220</td>
+
+  <td class='unitedstatescodetitle'>31</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title31-section1324&num=0&edition=prelim>1324</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1401(d)(2)</td>
+
+  <td class='statutesatlargepage'>220</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section31&num=0&edition=prelim>prec. 31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1401(d)(3)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6211&num=0&edition=prelim>6211</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1401(e)</td>
+
+  <td class='statutesatlargepage'>220</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section36B&num=0&edition=prelim>36B nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1402</td>
+
+  <td class='statutesatlargepage'>220</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18071&num=0&edition=prelim>18071</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1411</td>
+
+  <td class='statutesatlargepage'>224</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18081&num=0&edition=prelim>18081</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1412</td>
+
+  <td class='statutesatlargepage'>231</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18082&num=0&edition=prelim>18082</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1413</td>
+
+  <td class='statutesatlargepage'>233</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18083&num=0&edition=prelim>18083</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1414(a)(1)</td>
+
+  <td class='statutesatlargepage'>236</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6103&num=0&edition=prelim>6103</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1414(a)(2)</td>
+
+  <td class='statutesatlargepage'>237</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section405&num=0&edition=prelim>405</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1414(b), (c)</td>
+
+  <td class='statutesatlargepage'>237</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6103&num=0&edition=prelim>6103</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1414(d)</td>
+
+  <td class='statutesatlargepage'>237</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section7213&num=0&edition=prelim>7213</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1415</td>
+
+  <td class='statutesatlargepage'>237</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18084&num=0&edition=prelim>18084</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1421(a)</td>
+
+  <td class='statutesatlargepage'>237</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section45R&num=0&edition=prelim>45R</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1421(b), (c)</td>
+
+  <td class='statutesatlargepage'>241, 242</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section38&num=0&edition=prelim>38</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1421(d)(1)</td>
+
+  <td class='statutesatlargepage'>242</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section280C&num=0&edition=prelim>280C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1421(d)(2)</td>
+
+  <td class='statutesatlargepage'>242</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section196&num=0&edition=prelim>196</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1421(e)</td>
+
+  <td class='statutesatlargepage'>242</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section38&num=0&edition=prelim>prec. 38</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1421(f)</td>
+
+  <td class='statutesatlargepage'>242</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section38&num=0&edition=prelim>38 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1501(a)</td>
+
+  <td class='statutesatlargepage'>242</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18091&num=0&edition=prelim>18091</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1501(b)</td>
+
+  <td class='statutesatlargepage'>244</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000A&num=0&edition=prelim>prec. 5000A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1501(b)</td>
+
+  <td class='statutesatlargepage'>244</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000A&num=0&edition=prelim>5000A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1501(c)</td>
+
+  <td class='statutesatlargepage'>249</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4001&num=0&edition=prelim>prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1501(d)</td>
+
+  <td class='statutesatlargepage'>249</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000A&num=0&edition=prelim>5000A nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1502(a)</td>
+
+  <td class='statutesatlargepage'>250</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6055&num=0&edition=prelim>prec. 6055</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1502(a)</td>
+
+  <td class='statutesatlargepage'>250</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6055&num=0&edition=prelim>6055</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1502(b)</td>
+
+  <td class='statutesatlargepage'>251</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6724&num=0&edition=prelim>6724</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1502(c)</td>
+
+  <td class='statutesatlargepage'>251</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18092&num=0&edition=prelim>18092</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1502(d)</td>
+
+  <td class='statutesatlargepage'>251</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6031&num=0&edition=prelim>prec. 6031</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1502(e)</td>
+
+  <td class='statutesatlargepage'>252</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6055&num=0&edition=prelim>6055 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1511</td>
+
+  <td class='statutesatlargepage'>252</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section218a&num=0&edition=prelim>218a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1512</td>
+
+  <td class='statutesatlargepage'>252</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section218b&num=0&edition=prelim>218b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1513(a)</td>
+
+  <td class='statutesatlargepage'>253</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1513(b)</td>
+
+  <td class='statutesatlargepage'>256</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4971&num=0&edition=prelim>prec. 4971</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1513(d)</td>
+
+  <td class='statutesatlargepage'>256</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1514(a)</td>
+
+  <td class='statutesatlargepage'>256</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6056&num=0&edition=prelim>6056</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1514(b)</td>
+
+  <td class='statutesatlargepage'>257</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6724&num=0&edition=prelim>6724</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1514(c)</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6055&num=0&edition=prelim>prec. 6055</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1514(d)</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6056&num=0&edition=prelim>6056 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1515(a), (b)</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1515(c)</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1551</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18111&num=0&edition=prelim>18111</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1552</td>
+
+  <td class='statutesatlargepage'>258</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18112&num=0&edition=prelim>18112</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1553</td>
+
+  <td class='statutesatlargepage'>259</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18113&num=0&edition=prelim>18113</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1554</td>
+
+  <td class='statutesatlargepage'>259</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18114&num=0&edition=prelim>18114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1555</td>
+
+  <td class='statutesatlargepage'>260</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18115&num=0&edition=prelim>18115</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1556(a)</td>
+
+  <td class='statutesatlargepage'>260</td>
+
+  <td class='unitedstatescodetitle'>30</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title30-section921&num=0&edition=prelim>921</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1556(b)</td>
+
+  <td class='statutesatlargepage'>260</td>
+
+  <td class='unitedstatescodetitle'>30</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title30-section932&num=0&edition=prelim>932</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1556(c)</td>
+
+  <td class='statutesatlargepage'>260</td>
+
+  <td class='unitedstatescodetitle'>30</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title30-section921&num=0&edition=prelim>921 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1557</td>
+
+  <td class='statutesatlargepage'>260</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18116&num=0&edition=prelim>18116</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1558</td>
+
+  <td class='statutesatlargepage'>261</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section218c&num=0&edition=prelim>218c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1559</td>
+
+  <td class='statutesatlargepage'>261</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18117&num=0&edition=prelim>18117</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1560</td>
+
+  <td class='statutesatlargepage'>261</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18118&num=0&edition=prelim>18118</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1561</td>
+
+  <td class='statutesatlargepage'>262</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300jj-51&num=0&edition=prelim>300jj&ndash;51</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(a)</td>
+
+  <td class='statutesatlargepage'>264</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-21&num=0&edition=prelim>300gg&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(b)</td>
+
+  <td class='statutesatlargepage'>264</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-91&num=0&edition=prelim>300gg&ndash;91</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(1)</td>
+
+  <td class='statutesatlargepage'>264</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-3&num=0&edition=prelim>300gg&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(3)</td>
+
+  <td class='statutesatlargepage'>265</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-25&num=0&edition=prelim>300gg&ndash;25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(4)</td>
+
+  <td class='statutesatlargepage'>265</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-26&num=0&edition=prelim>300gg&ndash;26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(5)</td>
+
+  <td class='statutesatlargepage'>266</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-27&num=0&edition=prelim>300gg&ndash;27</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(6)</td>
+
+  <td class='statutesatlargepage'>266</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-28&num=0&edition=prelim>300gg&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(8)</td>
+
+  <td class='statutesatlargepage'>266</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-1&num=0&edition=prelim>300gg&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(9)</td>
+
+  <td class='statutesatlargepage'>267</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-12&num=0&edition=prelim>300gg&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(10)</td>
+
+  <td class='statutesatlargepage'>268</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-9&num=0&edition=prelim>300gg&ndash;9</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(12)</td>
+
+  <td class='statutesatlargepage'>268</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-21&num=0&edition=prelim>300gg&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(13)</td>
+
+  <td class='statutesatlargepage'>269</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-22&num=0&edition=prelim>300gg&ndash;22</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(14)</td>
+
+  <td class='statutesatlargepage'>269</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-23&num=0&edition=prelim>300gg&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(c)(15)</td>
+
+  <td class='statutesatlargepage'>269</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-62&num=0&edition=prelim>300gg&ndash;62</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(c)(16)</td>
+
+  <td class='statutesatlargepage'>269</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-91&num=0&edition=prelim>300gg&ndash;91</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18119&num=0&edition=prelim>18119</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(d)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18120&num=0&edition=prelim>18120</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>1563(e)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1185d&num=0&edition=prelim>1185d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>1563(f)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section9815&num=0&edition=prelim>9815</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(a)(1), (2)(A)</td>
+
+  <td class='statutesatlargepage'>271</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(a)(2)(B)</td>
+
+  <td class='statutesatlargepage'>272</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(a)(3)</td>
+
+  <td class='statutesatlargepage'>272</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(a)(4)(A)</td>
+
+  <td class='statutesatlargepage'>274</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(a)(4)(B)</td>
+
+  <td class='statutesatlargepage'>274</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-1&num=0&edition=prelim>1396r&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(a)(5)(A), (B)</td>
+
+  <td class='statutesatlargepage'>274</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(a)(5)(C)</td>
+
+  <td class='statutesatlargepage'>275</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(a)(5)(D)</td>
+
+  <td class='statutesatlargepage'>275</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(a)(5)(E)</td>
+
+  <td class='statutesatlargepage'>275</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396u-7&num=0&edition=prelim>1396u&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(b)</td>
+
+  <td class='statutesatlargepage'>275</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(c)</td>
+
+  <td class='statutesatlargepage'>276</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396u-7&num=0&edition=prelim>1396u&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(d)(1)</td>
+
+  <td class='statutesatlargepage'>277</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(d)(2)</td>
+
+  <td class='statutesatlargepage'>278</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(e)(1)</td>
+
+  <td class='statutesatlargepage'>278</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(e)(2)(A)</td>
+
+  <td class='statutesatlargepage'>279</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2001(e)(2)(B)</td>
+
+  <td class='statutesatlargepage'>279</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2001(e)(2)(C)</td>
+
+  <td class='statutesatlargepage'>279</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-1&num=0&edition=prelim>1396r&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2002(a), (b)</td>
+
+  <td class='statutesatlargepage'>279, 282</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2002(c)</td>
+
+  <td class='statutesatlargepage'>282</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2003(a), (b)</td>
+
+  <td class='statutesatlargepage'>282, 283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e-1&num=0&edition=prelim>1396e&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2003(c)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e-1&num=0&edition=prelim>1396e&ndash;1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2004(a)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2004(b)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-1&num=0&edition=prelim>1396r&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2004(c)(1)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2004(c)(2)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396u-7&num=0&edition=prelim>1396u&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2004(d)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2005(a), (b)</td>
+
+  <td class='statutesatlargepage'>283</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1308&num=0&edition=prelim>1308</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2005(c)(1)</td>
+
+  <td class='statutesatlargepage'>284</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2005(c)(2)</td>
+
+  <td class='statutesatlargepage'>284</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2006</td>
+
+  <td class='statutesatlargepage'>284</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2007(b)</td>
+
+  <td class='statutesatlargepage'>285</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396w-1&num=0&edition=prelim>1396w&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2101(a)&ndash;(c)</td>
+
+  <td class='statutesatlargepage'>286, 287</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ee&num=0&edition=prelim>1397ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2101(d)(1)</td>
+
+  <td class='statutesatlargepage'>287</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397bb&num=0&edition=prelim>1397bb</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2101(d)(2), (e)</td>
+
+  <td class='statutesatlargepage'>287</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397gg&num=0&edition=prelim>1397gg</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2101(f)</td>
+
+  <td class='statutesatlargepage'>287</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397jj&num=0&edition=prelim>1397jj nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2102(a)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2102(a)(1)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397dd&num=0&edition=prelim>1397dd</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2102(a)(2)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396&num=0&edition=prelim>1396 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2102(a)(3)&ndash;(5)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ee&num=0&edition=prelim>1397ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2102(a)(6)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ii&num=0&edition=prelim>1397ii</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2102(a)(7)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397jj&num=0&edition=prelim>1397jj</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2102(a)(8)</td>
+
+  <td class='statutesatlargepage'>288</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2102(b)</td>
+
+  <td class='statutesatlargepage'>289</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396o-1&num=0&edition=prelim>1396<em>o</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2102(b)</td>
+
+  <td class='statutesatlargepage'>289</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396o-1&num=0&edition=prelim>1396<em>o</em>&ndash;1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2201</td>
+
+  <td class='statutesatlargepage'>289</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396w-3&num=0&edition=prelim>1396w&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2202(a)</td>
+
+  <td class='statutesatlargepage'>291</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2202(b)</td>
+
+  <td class='statutesatlargepage'>291</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2202(c)</td>
+
+  <td class='statutesatlargepage'>292</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2301(a)</td>
+
+  <td class='statutesatlargepage'>292</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2301(b)</td>
+
+  <td class='statutesatlargepage'>292</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2301(c)</td>
+
+  <td class='statutesatlargepage'>293</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2302(a)</td>
+
+  <td class='statutesatlargepage'>293</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2302(b)</td>
+
+  <td class='statutesatlargepage'>293</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397jj&num=0&edition=prelim>1397jj</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2303(a)(1)&ndash;(3)</td>
+
+  <td class='statutesatlargepage'>293, 294</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2303(a)(4)(A)</td>
+
+  <td class='statutesatlargepage'>294</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2303(a)(4)(B)</td>
+
+  <td class='statutesatlargepage'>294</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2303(b)(1)</td>
+
+  <td class='statutesatlargepage'>294</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-1c&num=0&edition=prelim>1396r&ndash;1c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2303(b)(2)(A)</td>
+
+  <td class='statutesatlargepage'>296</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2303(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>296</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2303(c)</td>
+
+  <td class='statutesatlargepage'>296</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396u-7&num=0&edition=prelim>1396u&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2303(d)</td>
+
+  <td class='statutesatlargepage'>296</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2304</td>
+
+  <td class='statutesatlargepage'>296</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2401</td>
+
+  <td class='statutesatlargepage'>297</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396n&num=0&edition=prelim>1396n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2402(a)</td>
+
+  <td class='statutesatlargepage'>301</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396n&num=0&edition=prelim>1396n nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2402(b), (c)</td>
+
+  <td class='statutesatlargepage'>302, 303</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396n&num=0&edition=prelim>1396n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2402(d)(1)</td>
+
+  <td class='statutesatlargepage'>303</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2402(d)(2)(A)</td>
+
+  <td class='statutesatlargepage'>303</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2402(d)(2)(B)</td>
+
+  <td class='statutesatlargepage'>304</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2402(e), (f)</td>
+
+  <td class='statutesatlargepage'>304</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396n&num=0&edition=prelim>1396n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2402(g)</td>
+
+  <td class='statutesatlargepage'>304</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2403(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>304, 305</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2403(b)(2)</td>
+
+  <td class='statutesatlargepage'>305</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2404</td>
+
+  <td class='statutesatlargepage'>305</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-5&num=0&edition=prelim>1396r&ndash;5 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2501(a), (b)</td>
+
+  <td class='statutesatlargepage'>306, 307</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2501(c)(1)</td>
+
+  <td class='statutesatlargepage'>308</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2501(c)(2), (d)(1)</td>
+
+  <td class='statutesatlargepage'>308, 309</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2501(d)(2)</td>
+
+  <td class='statutesatlargepage'>309</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2501(e)</td>
+
+  <td class='statutesatlargepage'>309</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2501(f)(1)</td>
+
+  <td class='statutesatlargepage'>309</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256b&num=0&edition=prelim>256b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2501(f)(2)</td>
+
+  <td class='statutesatlargepage'>310</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256b&num=0&edition=prelim>256b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2502(a)</td>
+
+  <td class='statutesatlargepage'>310</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2502(b)</td>
+
+  <td class='statutesatlargepage'>310</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2503(a)&ndash;(c)</td>
+
+  <td class='statutesatlargepage'>310, 312</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2503(d)</td>
+
+  <td class='statutesatlargepage'>312</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2551(a)</td>
+
+  <td class='statutesatlargepage'>312</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-4&num=0&edition=prelim>1396r&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2551(b)</td>
+
+  <td class='statutesatlargepage'>314</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1396r&ndash;4 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2601(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>314, 315</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396n&num=0&edition=prelim>1396n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2601(b)(2)</td>
+
+  <td class='statutesatlargepage'>315</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315&num=0&edition=prelim>1315</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2602</td>
+
+  <td class='statutesatlargepage'>315</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315b&num=0&edition=prelim>1315b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2701</td>
+
+  <td class='statutesatlargepage'>317</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320b-9b&num=0&edition=prelim>1320b&ndash;9b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2702</td>
+
+  <td class='statutesatlargepage'>318</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b-1&num=0&edition=prelim>1396b&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2703(a)</td>
+
+  <td class='statutesatlargepage'>319</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396w-4&num=0&edition=prelim>1396w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2703(b)(2)</td>
+
+  <td class='statutesatlargepage'>322</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396w-4&num=0&edition=prelim>1396w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2704</td>
+
+  <td class='statutesatlargepage'>323</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2705</td>
+
+  <td class='statutesatlargepage'>324</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315a&num=0&edition=prelim>1315a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2706</td>
+
+  <td class='statutesatlargepage'>325</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2707</td>
+
+  <td class='statutesatlargepage'>326</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2801(a)</td>
+
+  <td class='statutesatlargepage'>328</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396&num=0&edition=prelim>1396</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2801(b)</td>
+
+  <td class='statutesatlargepage'>332</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-6&num=0&edition=prelim>1395b&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2901(a), (b)</td>
+
+  <td class='statutesatlargepage'>333</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1623&num=0&edition=prelim>1623</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2901(c)</td>
+
+  <td class='statutesatlargepage'>333</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2901(d)</td>
+
+  <td class='statutesatlargepage'>333</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320b-9&num=0&edition=prelim>1320b&ndash;9</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2902(a)</td>
+
+  <td class='statutesatlargepage'>333</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395qq&num=0&edition=prelim>1395qq</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2902(b)</td>
+
+  <td class='statutesatlargepage'>333</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395qq&num=0&edition=prelim>1395qq nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2951</td>
+
+  <td class='statutesatlargepage'>334</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section711&num=0&edition=prelim>711</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2952(a)</td>
+
+  <td class='statutesatlargepage'>344</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section712&num=0&edition=prelim>712 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2952(b)</td>
+
+  <td class='statutesatlargepage'>345</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section712&num=0&edition=prelim>712</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2953</td>
+
+  <td class='statutesatlargepage'>347</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section713&num=0&edition=prelim>713</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2954</td>
+
+  <td class='statutesatlargepage'>352</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section710&num=0&edition=prelim>710</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2955(a)</td>
+
+  <td class='statutesatlargepage'>352</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section675&num=0&edition=prelim>675</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2955(b)</td>
+
+  <td class='statutesatlargepage'>352</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section677&num=0&edition=prelim>677</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>2955(c)</td>
+
+  <td class='statutesatlargepage'>352</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section622&num=0&edition=prelim>622</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>2955(d)</td>
+
+  <td class='statutesatlargepage'>353</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section622&num=0&edition=prelim>622 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3001(a)(1)&ndash;(3)</td>
+
+  <td class='statutesatlargepage'>353&ndash;360</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3001(b)</td>
+
+  <td class='statutesatlargepage'>362</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3002(a)&ndash;(c)(1)</td>
+
+  <td class='statutesatlargepage'>363&ndash;365</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3002(c)(2)</td>
+
+  <td class='statutesatlargepage'>365</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3002(c)(3)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3002(d)&ndash;(f)</td>
+
+  <td class='statutesatlargepage'>365</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3003(a)</td>
+
+  <td class='statutesatlargepage'>366</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3003(b)</td>
+
+  <td class='statutesatlargepage'>367</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa&num=0&edition=prelim>1395aaa</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3004(a), (b)</td>
+
+  <td class='statutesatlargepage'>368, 369</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3004(c)</td>
+
+  <td class='statutesatlargepage'>370</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3005</td>
+
+  <td class='statutesatlargepage'>371</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc&num=0&edition=prelim>1395cc</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3007</td>
+
+  <td class='statutesatlargepage'>373</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3008(a)</td>
+
+  <td class='statutesatlargepage'>376</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3011</td>
+
+  <td class='statutesatlargepage'>378</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j&num=0&edition=prelim>280j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3012</td>
+
+  <td class='statutesatlargepage'>380</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j&num=0&edition=prelim>280j nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c&num=0&edition=prelim>299c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-1&num=0&edition=prelim>299c&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-2&num=0&edition=prelim>299c&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-3&num=0&edition=prelim>299c&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-4&num=0&edition=prelim>299c&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-5&num=0&edition=prelim>299c&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-6&num=0&edition=prelim>299c&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3013(a)(2)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-7&num=0&edition=prelim>299c&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(a)(3)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299c-7&num=0&edition=prelim>299c&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3013(a)(4)</td>
+
+  <td class='statutesatlargepage'>381</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-31&num=0&edition=prelim>299b&ndash;31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3013(b)</td>
+
+  <td class='statutesatlargepage'>383</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa-1&num=0&edition=prelim>1395aaa&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3014(a)</td>
+
+  <td class='statutesatlargepage'>384</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa&num=0&edition=prelim>1395aaa</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3014(b)</td>
+
+  <td class='statutesatlargepage'>385</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa-1&num=0&edition=prelim>1395aaa&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3015</td>
+
+  <td class='statutesatlargepage'>387</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j-1&num=0&edition=prelim>280j&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3015</td>
+
+  <td class='statutesatlargepage'>388</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j-2&num=0&edition=prelim>280j&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3021(a)</td>
+
+  <td class='statutesatlargepage'>389</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315a&num=0&edition=prelim>1315a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3021(b)</td>
+
+  <td class='statutesatlargepage'>394</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3021(c)</td>
+
+  <td class='statutesatlargepage'>395</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc-3&num=0&edition=prelim>1395cc&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3022</td>
+
+  <td class='statutesatlargepage'>395</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395jjj&num=0&edition=prelim>1395jjj</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3023</td>
+
+  <td class='statutesatlargepage'>399</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc-4&num=0&edition=prelim>1395cc&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3024</td>
+
+  <td class='statutesatlargepage'>404</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc-5&num=0&edition=prelim>1395cc&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3025(a)</td>
+
+  <td class='statutesatlargepage'>408</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3025(b)</td>
+
+  <td class='statutesatlargepage'>412</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j-3&num=0&edition=prelim>280j&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3026</td>
+
+  <td class='statutesatlargepage'>413</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-1&num=0&edition=prelim>1395b&ndash;1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3027</td>
+
+  <td class='statutesatlargepage'>415</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3101</td>
+
+  <td class='statutesatlargepage'>415</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3102</td>
+
+  <td class='statutesatlargepage'>416</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3103</td>
+
+  <td class='statutesatlargepage'>417</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3104</td>
+
+  <td class='statutesatlargepage'>417</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3105(a)</td>
+
+  <td class='statutesatlargepage'>417</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3105(b)</td>
+
+  <td class='statutesatlargepage'>417</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3105(c)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3106(a)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3106(b)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3107</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3108(a)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3108(b)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3109(a)</td>
+
+  <td class='statutesatlargepage'>418</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3109(b)</td>
+
+  <td class='statutesatlargepage'>419</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3109(c)</td>
+
+  <td class='statutesatlargepage'>420</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3110(a)(1)</td>
+
+  <td class='statutesatlargepage'>420</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395p&num=0&edition=prelim>1395p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3110(a)(2)</td>
+
+  <td class='statutesatlargepage'>420</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395p&num=0&edition=prelim>1395p nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3110(b)</td>
+
+  <td class='statutesatlargepage'>420</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395r&num=0&edition=prelim>1395r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3111(a)(1)</td>
+
+  <td class='statutesatlargepage'>421</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3111(a)(2)</td>
+
+  <td class='statutesatlargepage'>421</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3112</td>
+
+  <td class='statutesatlargepage'>421</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395iii&num=0&edition=prelim>1395iii</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3113</td>
+
+  <td class='statutesatlargepage'>422</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em> nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3114</td>
+
+  <td class='statutesatlargepage'>423</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3121</td>
+
+  <td class='statutesatlargepage'>423</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3122</td>
+
+  <td class='statutesatlargepage'>423</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em> nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3123</td>
+
+  <td class='statutesatlargepage'>423</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3124(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>424, 425</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3124(b)(2)</td>
+
+  <td class='statutesatlargepage'>425</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3125</td>
+
+  <td class='statutesatlargepage'>425</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3126</td>
+
+  <td class='statutesatlargepage'>425</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-4&num=0&edition=prelim>1395i&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3128(a)</td>
+
+  <td class='statutesatlargepage'>426</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3128(b)</td>
+
+  <td class='statutesatlargepage'>426</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3129(a), (b)</td>
+
+  <td class='statutesatlargepage'>426</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-4&num=0&edition=prelim>1395i&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3129(c)</td>
+
+  <td class='statutesatlargepage'>427</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-4&num=0&edition=prelim>1395i&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3131(a)(1)</td>
+
+  <td class='statutesatlargepage'>427</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3131(b)</td>
+
+  <td class='statutesatlargepage'>428</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3131(c)</td>
+
+  <td class='statutesatlargepage'>428</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3131(d)</td>
+
+  <td class='statutesatlargepage'>429</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3132</td>
+
+  <td class='statutesatlargepage'>430</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3133</td>
+
+  <td class='statutesatlargepage'>432</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3134(a)</td>
+
+  <td class='statutesatlargepage'>434</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3134(b)(1)</td>
+
+  <td class='statutesatlargepage'>435</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3134(b)(1)(C)</td>
+
+  <td class='statutesatlargepage'>435</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395w&ndash;4 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3134(b)(2)</td>
+
+  <td class='statutesatlargepage'>435</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ee&num=0&edition=prelim>1395ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3135(a), (b)</td>
+
+  <td class='statutesatlargepage'>436, 437</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3136(a), (b)</td>
+
+  <td class='statutesatlargepage'>437, 438</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3136(c)</td>
+
+  <td class='statutesatlargepage'>438</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3137(a)(1)</td>
+
+  <td class='statutesatlargepage'>438</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3137(a)(2)</td>
+
+  <td class='statutesatlargepage'>438</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3137(b), (c)</td>
+
+  <td class='statutesatlargepage'>438, 439</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3138</td>
+
+  <td class='statutesatlargepage'>439</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3139(a)</td>
+
+  <td class='statutesatlargepage'>439</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-3a&num=0&edition=prelim>1395w&ndash;3a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3139(b)</td>
+
+  <td class='statutesatlargepage'>440</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-3a&num=0&edition=prelim>1395w&ndash;3a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3140</td>
+
+  <td class='statutesatlargepage'>440</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395d&num=0&edition=prelim>1395d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3141</td>
+
+  <td class='statutesatlargepage'>441</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3143</td>
+
+  <td class='statutesatlargepage'>442</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395d&num=0&edition=prelim>1395d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(a)(1), (2)(A)</td>
+
+  <td class='statutesatlargepage'>442, 444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(a)(2)(B)</td>
+
+  <td class='statutesatlargepage'>444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(a)(2)(C)</td>
+
+  <td class='statutesatlargepage'>444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27a&num=0&edition=prelim>1395w&ndash;27a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(a)(2)(D)</td>
+
+  <td class='statutesatlargepage'>444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395w&ndash;29</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(b)</td>
+
+  <td class='statutesatlargepage'>444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(c)&ndash;(d)(2)</td>
+
+  <td class='statutesatlargepage'>444</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(d)(3)</td>
+
+  <td class='statutesatlargepage'>445</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395w&ndash;24 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(e)(1)</td>
+
+  <td class='statutesatlargepage'>445</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(e)(2)(A)(i)</td>
+
+  <td class='statutesatlargepage'>446</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-21&num=0&edition=prelim>1395w&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(e)(2)(A)(ii)&ndash;(iv)</td>
+
+  <td class='statutesatlargepage'>446, 447</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(e)(2)(A)(v)</td>
+
+  <td class='statutesatlargepage'>447</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(e)(2)(B)</td>
+
+  <td class='statutesatlargepage'>447</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395w&ndash;21 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(f)(1)</td>
+
+  <td class='statutesatlargepage'>447</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(f)(2)</td>
+
+  <td class='statutesatlargepage'>450</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27a&num=0&edition=prelim>1395w&ndash;27a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(g), (h)</td>
+
+  <td class='statutesatlargepage'>450, 452</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3201(i)(1)</td>
+
+  <td class='statutesatlargepage'>453</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395eee&num=0&edition=prelim>1395eee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3201(i)(2)</td>
+
+  <td class='statutesatlargepage'>454</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3202(a)(1)</td>
+
+  <td class='statutesatlargepage'>454</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-22&num=0&edition=prelim>1395w&ndash;22</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3202(a)(2)</td>
+
+  <td class='statutesatlargepage'>454</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-22&num=0&edition=prelim>1395w&ndash;22 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3202(b)(1)</td>
+
+  <td class='statutesatlargepage'>454</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3202(b)(2)</td>
+
+  <td class='statutesatlargepage'>455</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3202(b)(3)</td>
+
+  <td class='statutesatlargepage'>455</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3203</td>
+
+  <td class='statutesatlargepage'>456</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3204(a)(1)</td>
+
+  <td class='statutesatlargepage'>456</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-21&num=0&edition=prelim>1395w&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3204(a)(2)</td>
+
+  <td class='statutesatlargepage'>456</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-21&num=0&edition=prelim>1395w&ndash;21 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3204(b)</td>
+
+  <td class='statutesatlargepage'>456</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-21&num=0&edition=prelim>1395w&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3205(a)</td>
+
+  <td class='statutesatlargepage'>457</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3205(b)</td>
+
+  <td class='statutesatlargepage'>457</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3205(c)</td>
+
+  <td class='statutesatlargepage'>457</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3205(d)</td>
+
+  <td class='statutesatlargepage'>458</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3205(e)</td>
+
+  <td class='statutesatlargepage'>458</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3205(f)</td>
+
+  <td class='statutesatlargepage'>458</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3205(g)</td>
+
+  <td class='statutesatlargepage'>459</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3206</td>
+
+  <td class='statutesatlargepage'>459</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395mm&num=0&edition=prelim>1395mm</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3207</td>
+
+  <td class='statutesatlargepage'>459</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27&num=0&edition=prelim>1395w&ndash;27 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3208(a)</td>
+
+  <td class='statutesatlargepage'>459</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3208(b)</td>
+
+  <td class='statutesatlargepage'>460</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-28&num=0&edition=prelim>1395w&ndash;28 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3209(a)</td>
+
+  <td class='statutesatlargepage'>460</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3209(b)</td>
+
+  <td class='statutesatlargepage'>460</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-111&num=0&edition=prelim>1395w&ndash;111</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3209(c)</td>
+
+  <td class='statutesatlargepage'>460</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-24&num=0&edition=prelim>1395w&ndash;24 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3210</td>
+
+  <td class='statutesatlargepage'>460</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ss&num=0&edition=prelim>1395ss</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3301(a)</td>
+
+  <td class='statutesatlargepage'>461</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-153&num=0&edition=prelim>1395w&ndash;153</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3301(b)</td>
+
+  <td class='statutesatlargepage'>462</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114a&num=0&edition=prelim>1395w&ndash;114a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3301(c)(1)</td>
+
+  <td class='statutesatlargepage'>467</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-102&num=0&edition=prelim>1395w&ndash;102</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3301(c)(2)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-102&num=0&edition=prelim>1395w&ndash;102 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3301(d)(1)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7b&num=0&edition=prelim>1320a&ndash;7b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3301(d)(2)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3301(d)(3)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7b&num=0&edition=prelim>1320a&ndash;7b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3302(a)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3302(b)</td>
+
+  <td class='statutesatlargepage'>468</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3303(a)</td>
+
+  <td class='statutesatlargepage'>469</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3303(b)</td>
+
+  <td class='statutesatlargepage'>469</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-101&num=0&edition=prelim>1395w&ndash;101</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3303(c)</td>
+
+  <td class='statutesatlargepage'>469</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-101&num=0&edition=prelim>1395w&ndash;101 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3304(a)</td>
+
+  <td class='statutesatlargepage'>469</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3304(b)</td>
+
+  <td class='statutesatlargepage'>470</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3305</td>
+
+  <td class='statutesatlargepage'>470</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3306</td>
+
+  <td class='statutesatlargepage'>470</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-3&num=0&edition=prelim>1395b&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3307(a)</td>
+
+  <td class='statutesatlargepage'>471</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3307(b)</td>
+
+  <td class='statutesatlargepage'>472</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3308(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>472, 474</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-113&num=0&edition=prelim>1395w&ndash;113</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3308(b)(2)</td>
+
+  <td class='statutesatlargepage'>474</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6103&num=0&edition=prelim>6103</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3309</td>
+
+  <td class='statutesatlargepage'>475</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-114&num=0&edition=prelim>1395w&ndash;114</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3310(a)</td>
+
+  <td class='statutesatlargepage'>475</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3310(b)</td>
+
+  <td class='statutesatlargepage'>475</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3311</td>
+
+  <td class='statutesatlargepage'>475</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-154&num=0&edition=prelim>1395w&ndash;154</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3312(a)</td>
+
+  <td class='statutesatlargepage'>476</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3312(b)</td>
+
+  <td class='statutesatlargepage'>476</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3313</td>
+
+  <td class='statutesatlargepage'>477</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-101&num=0&edition=prelim>1395w&ndash;101 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3314(a)</td>
+
+  <td class='statutesatlargepage'>478</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-102&num=0&edition=prelim>1395w&ndash;102</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3314(b)</td>
+
+  <td class='statutesatlargepage'>479</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-102&num=0&edition=prelim>1395w&ndash;102 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3315</td>
+
+  <td class='statutesatlargepage'>479</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-102&num=0&edition=prelim>1395w&ndash;102</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(a)</td>
+
+  <td class='statutesatlargepage'>480</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(b)</td>
+
+  <td class='statutesatlargepage'>481</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395yy&num=0&edition=prelim>1395yy</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(c), (d)</td>
+
+  <td class='statutesatlargepage'>481, 482</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(e)</td>
+
+  <td class='statutesatlargepage'>483</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(f)</td>
+
+  <td class='statutesatlargepage'>483</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(g)</td>
+
+  <td class='statutesatlargepage'>484</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(h)</td>
+
+  <td class='statutesatlargepage'>485</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395rr&num=0&edition=prelim>1395rr</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(i)</td>
+
+  <td class='statutesatlargepage'>485</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(j)</td>
+
+  <td class='statutesatlargepage'>486</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(k), (<em>l</em>)</td>
+
+  <td class='statutesatlargepage'>486, 487</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(m), (n)</td>
+
+  <td class='statutesatlargepage'>487</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3401(<em>o</em>)</td>
+
+  <td class='statutesatlargepage'>488</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395u&num=0&edition=prelim>1395u</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3401(p)</td>
+
+  <td class='statutesatlargepage'>488</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3402</td>
+
+  <td class='statutesatlargepage'>488</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395r&num=0&edition=prelim>1395r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3403(a)(1)</td>
+
+  <td class='statutesatlargepage'>489</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk&num=0&edition=prelim>1395kkk</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3403(a)(2)</td>
+
+  <td class='statutesatlargepage'>506</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section207&num=0&edition=prelim>207</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3403(b)</td>
+
+  <td class='statutesatlargepage'>506</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk-1&num=0&edition=prelim>1395kkk&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3403(c)</td>
+
+  <td class='statutesatlargepage'>507</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-6&num=0&edition=prelim>1395b&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3501</td>
+
+  <td class='statutesatlargepage'>508</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-33&num=0&edition=prelim>299b&ndash;33</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3501</td>
+
+  <td class='statutesatlargepage'>511</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-34&num=0&edition=prelim>299b&ndash;34</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3502</td>
+
+  <td class='statutesatlargepage'>513</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256a-1&num=0&edition=prelim>256a&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3503</td>
+
+  <td class='statutesatlargepage'>516</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-35&num=0&edition=prelim>299b&ndash;35</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3504(a)(1)</td>
+
+  <td class='statutesatlargepage'>518</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-5&num=0&edition=prelim>300d&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3504(a)(2)</td>
+
+  <td class='statutesatlargepage'>518</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-6&num=0&edition=prelim>300d&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3504(a)(3)</td>
+
+  <td class='statutesatlargepage'>520</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-32&num=0&edition=prelim>300d&ndash;32</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3504(b)</td>
+
+  <td class='statutesatlargepage'>521</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section289g-4&num=0&edition=prelim>289g&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3505(a)(1)</td>
+
+  <td class='statutesatlargepage'>522</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-41&num=0&edition=prelim>300d&ndash;41</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3505(a)(2)</td>
+
+  <td class='statutesatlargepage'>523</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-42&num=0&edition=prelim>300d&ndash;42</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3505(a)(3)</td>
+
+  <td class='statutesatlargepage'>524</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-43&num=0&edition=prelim>300d&ndash;43</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3505(a)(4)</td>
+
+  <td class='statutesatlargepage'>524</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-44&num=0&edition=prelim>300d&ndash;44</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3505(a)(5)</td>
+
+  <td class='statutesatlargepage'>525</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-45&num=0&edition=prelim>300d&ndash;45</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3505(a)(6)</td>
+
+  <td class='statutesatlargepage'>525</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-46&num=0&edition=prelim>300d&ndash;46</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3505(b)</td>
+
+  <td class='statutesatlargepage'>525</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-81&num=0&edition=prelim>300d&ndash;81</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3505(b)</td>
+
+  <td class='statutesatlargepage'>527</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300d-82&num=0&edition=prelim>300d&ndash;82</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3506</td>
+
+  <td class='statutesatlargepage'>527</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-36&num=0&edition=prelim>299b&ndash;36</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3507</td>
+
+  <td class='statutesatlargepage'>530</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section352&num=0&edition=prelim>352 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3508</td>
+
+  <td class='statutesatlargepage'>530</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294j&num=0&edition=prelim>294j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(a)(1)</td>
+
+  <td class='statutesatlargepage'>531</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section237a&num=0&edition=prelim>237a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(a)(2)</td>
+
+  <td class='statutesatlargepage'>533</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section237a&num=0&edition=prelim>237a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(b)</td>
+
+  <td class='statutesatlargepage'>533</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section242s&num=0&edition=prelim>242s</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(c)</td>
+
+  <td class='statutesatlargepage'>534</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section287d&num=0&edition=prelim>287d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(d)</td>
+
+  <td class='statutesatlargepage'>534</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section290aa&num=0&edition=prelim>290aa</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(e)(1)</td>
+
+  <td class='statutesatlargepage'>534</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-25&num=0&edition=prelim>299b&ndash;25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(e)(1)</td>
+
+  <td class='statutesatlargepage'>534</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-26&num=0&edition=prelim>299b&ndash;26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(e)(2)</td>
+
+  <td class='statutesatlargepage'>534</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-24a&num=0&edition=prelim>299b&ndash;24a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(f)</td>
+
+  <td class='statutesatlargepage'>535</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section914&num=0&edition=prelim>914</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(g)</td>
+
+  <td class='statutesatlargepage'>536</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section399b&num=0&edition=prelim>399b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(h)</td>
+
+  <td class='statutesatlargepage'>537</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section237a&num=0&edition=prelim>237a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3509(i)</td>
+
+  <td class='statutesatlargepage'>537</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section237a&num=0&edition=prelim>237a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3509(j)</td>
+
+  <td class='statutesatlargepage'>537</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section237a&num=0&edition=prelim>237a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3510</td>
+
+  <td class='statutesatlargepage'>537</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256a&num=0&edition=prelim>256a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>3601</td>
+
+  <td class='statutesatlargepage'>538</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395&num=0&edition=prelim>1395 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>3602</td>
+
+  <td class='statutesatlargepage'>538</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-21&num=0&edition=prelim>1395w&ndash;21 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4001</td>
+
+  <td class='statutesatlargepage'>538</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-10&num=0&edition=prelim>300u&ndash;10</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4002</td>
+
+  <td class='statutesatlargepage'>541</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-11&num=0&edition=prelim>300u&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4003(a)</td>
+
+  <td class='statutesatlargepage'>541</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-4&num=0&edition=prelim>299b&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4003(b)(1)</td>
+
+  <td class='statutesatlargepage'>543</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-10&num=0&edition=prelim>280g&ndash;10</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4003(b)(2)(A)</td>
+
+  <td class='statutesatlargepage'>544</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-7&num=0&edition=prelim>280g&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4003(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>544</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-8&num=0&edition=prelim>280g&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4004</td>
+
+  <td class='statutesatlargepage'>544</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-12&num=0&edition=prelim>300u&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4101(a)</td>
+
+  <td class='statutesatlargepage'>546</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280h-4&num=0&edition=prelim>280h&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4101(b)</td>
+
+  <td class='statutesatlargepage'>547</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280h-5&num=0&edition=prelim>280h&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4102(a)</td>
+
+  <td class='statutesatlargepage'>550</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280k&num=0&edition=prelim>280k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4102(a)</td>
+
+  <td class='statutesatlargepage'>551</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280k-1&num=0&edition=prelim>280k&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4102(a)</td>
+
+  <td class='statutesatlargepage'>551</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280k-2&num=0&edition=prelim>280k&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4102(b), (c)</td>
+
+  <td class='statutesatlargepage'>551, 552</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section247b-14&num=0&edition=prelim>247b&ndash;14</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4102(d)</td>
+
+  <td class='statutesatlargepage'>552</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280k-3&num=0&edition=prelim>280k&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4103(a), (b)</td>
+
+  <td class='statutesatlargepage'>553</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4103(c)(1)</td>
+
+  <td class='statutesatlargepage'>555</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4103(c)(2)</td>
+
+  <td class='statutesatlargepage'>556</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4103(c)(3), (4)</td>
+
+  <td class='statutesatlargepage'>556</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4103(d)</td>
+
+  <td class='statutesatlargepage'>556</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395y&num=0&edition=prelim>1395y</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4103(e)</td>
+
+  <td class='statutesatlargepage'>557</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em> nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4104(a)</td>
+
+  <td class='statutesatlargepage'>557</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4104(b), (c)</td>
+
+  <td class='statutesatlargepage'>557, 558</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4104(d)</td>
+
+  <td class='statutesatlargepage'>558</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em> nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4105(a)</td>
+
+  <td class='statutesatlargepage'>558</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4105(b)</td>
+
+  <td class='statutesatlargepage'>559</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4106(a), (b)</td>
+
+  <td class='statutesatlargepage'>559</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4106(c)</td>
+
+  <td class='statutesatlargepage'>560</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4107(a)</td>
+
+  <td class='statutesatlargepage'>560</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4107(b)</td>
+
+  <td class='statutesatlargepage'>560</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-8&num=0&edition=prelim>1396r&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4107(c)(1)</td>
+
+  <td class='statutesatlargepage'>561</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396o&num=0&edition=prelim>1396<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4107(c)(2)</td>
+
+  <td class='statutesatlargepage'>561</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396o-1&num=0&edition=prelim>1396<em>o</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4107(d)</td>
+
+  <td class='statutesatlargepage'>561</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4108</td>
+
+  <td class='statutesatlargepage'>561</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4201</td>
+
+  <td class='statutesatlargepage'>564</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-13&num=0&edition=prelim>300u&ndash;13</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4202</td>
+
+  <td class='statutesatlargepage'>566</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-14&num=0&edition=prelim>300u&ndash;14</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4203</td>
+
+  <td class='statutesatlargepage'>570</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section794f&num=0&edition=prelim>794f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4204(a)&ndash;(c)</td>
+
+  <td class='statutesatlargepage'>571, 572</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section247b&num=0&edition=prelim>247b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4204(d)</td>
+
+  <td class='statutesatlargepage'>572</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section247b&num=0&edition=prelim>247b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4205(a), (b)</td>
+
+  <td class='statutesatlargepage'>573</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section343&num=0&edition=prelim>343</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4205(c)</td>
+
+  <td class='statutesatlargepage'>576</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section343-1&num=0&edition=prelim>343&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4205(d)</td>
+
+  <td class='statutesatlargepage'>576</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section343&num=0&edition=prelim>343 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4206</td>
+
+  <td class='statutesatlargepage'>576</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b&num=0&edition=prelim>254b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4207</td>
+
+  <td class='statutesatlargepage'>577</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section207&num=0&edition=prelim>207</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4301</td>
+
+  <td class='statutesatlargepage'>578</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-15&num=0&edition=prelim>300u&ndash;15</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4302(a)</td>
+
+  <td class='statutesatlargepage'>578</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300kk&num=0&edition=prelim>300kk</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4302(b)(1)(A)</td>
+
+  <td class='statutesatlargepage'>581</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4302(b)(1)(B)</td>
+
+  <td class='statutesatlargepage'>581</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397hh&num=0&edition=prelim>1397hh</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4302(b)(2)</td>
+
+  <td class='statutesatlargepage'>581</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396w-5&num=0&edition=prelim>1396w&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4303</td>
+
+  <td class='statutesatlargepage'>583</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l&num=0&edition=prelim>280<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4303</td>
+
+  <td class='statutesatlargepage'>583</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l-1&num=0&edition=prelim>280<em>l</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4303</td>
+
+  <td class='statutesatlargepage'>583</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l-2&num=0&edition=prelim>280<em>l</em>&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4303</td>
+
+  <td class='statutesatlargepage'>583</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l-3&num=0&edition=prelim>280<em>l</em>&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4304</td>
+
+  <td class='statutesatlargepage'>584</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300hh-31&num=0&edition=prelim>300hh&ndash;31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4305(b)</td>
+
+  <td class='statutesatlargepage'>585</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section284q&num=0&edition=prelim>284q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>4305(c)</td>
+
+  <td class='statutesatlargepage'>586</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294i&num=0&edition=prelim>294i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>4306</td>
+
+  <td class='statutesatlargepage'>587</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320b-9a&num=0&edition=prelim>1320b&ndash;9a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5001</td>
+
+  <td class='statutesatlargepage'>588</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294q&num=0&edition=prelim>294q nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5002(a)</td>
+
+  <td class='statutesatlargepage'>588</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294q&num=0&edition=prelim>294q nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5002(b)</td>
+
+  <td class='statutesatlargepage'>590</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295p&num=0&edition=prelim>295p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5002(c)</td>
+
+  <td class='statutesatlargepage'>591</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296&num=0&edition=prelim>296</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5101</td>
+
+  <td class='statutesatlargepage'>592</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294q&num=0&edition=prelim>294q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5102</td>
+
+  <td class='statutesatlargepage'>599</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294r&num=0&edition=prelim>294r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5103(a)</td>
+
+  <td class='statutesatlargepage'>603</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294n&num=0&edition=prelim>294n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5103(b)</td>
+
+  <td class='statutesatlargepage'>605</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294n&num=0&edition=prelim>294n nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5103(c)</td>
+
+  <td class='statutesatlargepage'>605</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295j&num=0&edition=prelim>295j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5103(d)(1)</td>
+
+  <td class='statutesatlargepage'>605</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293l&num=0&edition=prelim>293<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5103(d)(2)</td>
+
+  <td class='statutesatlargepage'>606</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294f&num=0&edition=prelim>294f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5103(d)(3)</td>
+
+  <td class='statutesatlargepage'>606</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294o&num=0&edition=prelim>294<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5201(a)</td>
+
+  <td class='statutesatlargepage'>606</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section292s&num=0&edition=prelim>292s</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5201(b)</td>
+
+  <td class='statutesatlargepage'>607</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section292s&num=0&edition=prelim>292s nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5202</td>
+
+  <td class='statutesatlargepage'>607</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297b&num=0&edition=prelim>297b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5203</td>
+
+  <td class='statutesatlargepage'>607</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295f&num=0&edition=prelim>295f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5204</td>
+
+  <td class='statutesatlargepage'>609</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295f-1&num=0&edition=prelim>295f&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5205(a)</td>
+
+  <td class='statutesatlargepage'>611</td>
+
+  <td class='unitedstatescodetitle'>20</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title20-section1078-11&num=0&edition=prelim>1078&ndash;11 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5205(b)</td>
+
+  <td class='statutesatlargepage'>611</td>
+
+  <td class='unitedstatescodetitle'>20</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title20-section1078-11&num=0&edition=prelim>1078&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5206(a)</td>
+
+  <td class='statutesatlargepage'>611</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295&num=0&edition=prelim>295</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5206(b)</td>
+
+  <td class='statutesatlargepage'>612</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295f-2&num=0&edition=prelim>295f&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5207</td>
+
+  <td class='statutesatlargepage'>612</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254q&num=0&edition=prelim>254q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5208(a)</td>
+
+  <td class='statutesatlargepage'>612</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254c-1a&num=0&edition=prelim>254c&ndash;1a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5208(b)</td>
+
+  <td class='statutesatlargepage'>613</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254c-1a&num=0&edition=prelim>254c&ndash;1a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5209</td>
+
+  <td class='statutesatlargepage'>613</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section238f&num=0&edition=prelim>238f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5210</td>
+
+  <td class='statutesatlargepage'>614</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section204&num=0&edition=prelim>204</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5301</td>
+
+  <td class='statutesatlargepage'>615</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>293k</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5301</td>
+
+  <td class='statutesatlargepage'>615</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293k&num=0&edition=prelim>293k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5302</td>
+
+  <td class='statutesatlargepage'>617</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293k-1&num=0&edition=prelim>293k&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5303(1)</td>
+
+  <td class='statutesatlargepage'>618</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293l&num=0&edition=prelim>293<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5303(2)</td>
+
+  <td class='statutesatlargepage'>618</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293k-2&num=0&edition=prelim>293k&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5304</td>
+
+  <td class='statutesatlargepage'>621</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256g-1&num=0&edition=prelim>256g&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5305(a), (b)</td>
+
+  <td class='statutesatlargepage'>622, 624</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294c&num=0&edition=prelim>294c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5305(c)</td>
+
+  <td class='statutesatlargepage'>625</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section298&num=0&edition=prelim>298</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5306(a)(1)</td>
+
+  <td class='statutesatlargepage'>626</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>294g</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5306(a)(2)</td>
+
+  <td class='statutesatlargepage'>626</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294f&num=0&edition=prelim>294f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5306(a)(3)</td>
+
+  <td class='statutesatlargepage'>626</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294e-1&num=0&edition=prelim>294e&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5306(b)</td>
+
+  <td class='statutesatlargepage'>628</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294f&num=0&edition=prelim>294f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5307(a)</td>
+
+  <td class='statutesatlargepage'>628</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293e&num=0&edition=prelim>293e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5307(b)</td>
+
+  <td class='statutesatlargepage'>628</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296e-1&num=0&edition=prelim>296e&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5308</td>
+
+  <td class='statutesatlargepage'>629</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296j&num=0&edition=prelim>296j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5309(a)</td>
+
+  <td class='statutesatlargepage'>629</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296p&num=0&edition=prelim>296p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5309(b)</td>
+
+  <td class='statutesatlargepage'>630</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296p-1&num=0&edition=prelim>296p&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(a)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297n&num=0&edition=prelim>297n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(1)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296g&num=0&edition=prelim>296g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(2)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297a&num=0&edition=prelim>297a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(2)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297b&num=0&edition=prelim>297b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(2)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297d&num=0&edition=prelim>297d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(2)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297g&num=0&edition=prelim>297g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(2)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297i&num=0&edition=prelim>297i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(3), (4)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297b&num=0&edition=prelim>297b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(5)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297e&num=0&edition=prelim>297e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(6)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297a&num=0&edition=prelim>297a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(7)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section298d&num=0&edition=prelim>298d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(8)(A)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297t&num=0&edition=prelim>297t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(9)(A)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297w&num=0&edition=prelim>297w</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5310(b)(9)(A)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297x&num=0&edition=prelim>297x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5310(b)(10)(A)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section298&num=0&edition=prelim>298</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5311(a)</td>
+
+  <td class='statutesatlargepage'>631</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297n-1&num=0&edition=prelim>297n&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5311(b)</td>
+
+  <td class='statutesatlargepage'>632</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section297o&num=0&edition=prelim>297<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5312</td>
+
+  <td class='statutesatlargepage'>633</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section298d&num=0&edition=prelim>298d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5313(a)</td>
+
+  <td class='statutesatlargepage'>633</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-11&num=0&edition=prelim>280g&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5314</td>
+
+  <td class='statutesatlargepage'>636</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295f-3&num=0&edition=prelim>295f&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5315</td>
+
+  <td class='statutesatlargepage'>637</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section239l&num=0&edition=prelim>239<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5315</td>
+
+  <td class='statutesatlargepage'>637</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section239l-1&num=0&edition=prelim>239<em>l</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5315</td>
+
+  <td class='statutesatlargepage'>639</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section239l-2&num=0&edition=prelim>239<em>l</em>&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5315</td>
+
+  <td class='statutesatlargepage'>642</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section239l-3&num=0&edition=prelim>239<em>l</em>&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5316</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296j-1&num=0&edition=prelim>296j&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5401</td>
+
+  <td class='statutesatlargepage'>642</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293&num=0&edition=prelim>293</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5402(a)</td>
+
+  <td class='statutesatlargepage'>644</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293b&num=0&edition=prelim>293b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5402(b)&ndash;(d)</td>
+
+  <td class='statutesatlargepage'>644</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293d&num=0&edition=prelim>293d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5403(a)</td>
+
+  <td class='statutesatlargepage'>644</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294a&num=0&edition=prelim>294a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5403(b)</td>
+
+  <td class='statutesatlargepage'>648</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>294b</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5403(b)</td>
+
+  <td class='statutesatlargepage'>648</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294b&num=0&edition=prelim>294b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5404</td>
+
+  <td class='statutesatlargepage'>649</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296m&num=0&edition=prelim>296m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5405</td>
+
+  <td class='statutesatlargepage'>649</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-12&num=0&edition=prelim>280g&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5501(a)(1)</td>
+
+  <td class='statutesatlargepage'>652</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5501(a)(2)</td>
+
+  <td class='statutesatlargepage'>653</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5501(b)(1)</td>
+
+  <td class='statutesatlargepage'>653</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5501(b)(2)</td>
+
+  <td class='statutesatlargepage'>654</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5501(c)</td>
+
+  <td class='statutesatlargepage'>654</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5502(a)(1)</td>
+
+  <td class='statutesatlargepage'>654</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5502(a)(2)</td>
+
+  <td class='statutesatlargepage'>654</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395x nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5502(b)</td>
+
+  <td class='statutesatlargepage'>654</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5503(a), (b)</td>
+
+  <td class='statutesatlargepage'>655, 658</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5503(c)</td>
+
+  <td class='statutesatlargepage'>659</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5504(a), (b)</td>
+
+  <td class='statutesatlargepage'>659</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5504(c)</td>
+
+  <td class='statutesatlargepage'>660</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5505(a), (b)</td>
+
+  <td class='statutesatlargepage'>660</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5505(c)</td>
+
+  <td class='statutesatlargepage'>661</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5505(d)</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5506(a), (b)</td>
+
+  <td class='statutesatlargepage'>661, 662</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5506(c)</td>
+
+  <td class='statutesatlargepage'>662</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5506(d)</td>
+
+  <td class='statutesatlargepage'>662</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5506(e)</td>
+
+  <td class='statutesatlargepage'>663</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5507(a)</td>
+
+  <td class='statutesatlargepage'>663</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397g&num=0&edition=prelim>1397g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5507(b)</td>
+
+  <td class='statutesatlargepage'>668</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section701&num=0&edition=prelim>701</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5508(a)</td>
+
+  <td class='statutesatlargepage'>668</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293l-1&num=0&edition=prelim>293<em>l</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5508(b)</td>
+
+  <td class='statutesatlargepage'>670</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254m&num=0&edition=prelim>254m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5508(c)</td>
+
+  <td class='statutesatlargepage'>670</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256h&num=0&edition=prelim>256h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5509</td>
+
+  <td class='statutesatlargepage'>674</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5601</td>
+
+  <td class='statutesatlargepage'>676</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b&num=0&edition=prelim>254b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5602</td>
+
+  <td class='statutesatlargepage'>677</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b&num=0&edition=prelim>254b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5603</td>
+
+  <td class='statutesatlargepage'>679</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300w-9&num=0&edition=prelim>300w&ndash;9</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5604</td>
+
+  <td class='statutesatlargepage'>679</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section290bb-42&num=0&edition=prelim>290bb&ndash;42</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5605</td>
+
+  <td class='statutesatlargepage'>680</td>
+
+  <td class='unitedstatescodetitle'>36</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title36-section150303&num=0&edition=prelim>150303 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>5606</td>
+
+  <td class='statutesatlargepage'></td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b-1&num=0&edition=prelim>254b&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>5701</td>
+
+  <td class='statutesatlargepage'>684</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section204&num=0&edition=prelim>204 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6001(a)</td>
+
+  <td class='statutesatlargepage'>684</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6001(b)</td>
+
+  <td class='statutesatlargepage'>689</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6002</td>
+
+  <td class='statutesatlargepage'>689</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7h&num=0&edition=prelim>1320a&ndash;7h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6003(a)</td>
+
+  <td class='statutesatlargepage'>697</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6003(b)</td>
+
+  <td class='statutesatlargepage'>697</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6004</td>
+
+  <td class='statutesatlargepage'>697</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7i&num=0&edition=prelim>1320a&ndash;7i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6005</td>
+
+  <td class='statutesatlargepage'>698</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320b-23&num=0&edition=prelim>1320b&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6101(a)</td>
+
+  <td class='statutesatlargepage'>699</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-3&num=0&edition=prelim>1320a&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6101(b)</td>
+
+  <td class='statutesatlargepage'>702</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-3&num=0&edition=prelim>1320a&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6101(c)(1)(A)</td>
+
+  <td class='statutesatlargepage'>702</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6101(c)(1)(B)</td>
+
+  <td class='statutesatlargepage'>702</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6101(c)(2)</td>
+
+  <td class='statutesatlargepage'>702</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6102</td>
+
+  <td class='statutesatlargepage'>702</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(a)(1), (2)(A)</td>
+
+  <td class='statutesatlargepage'>704, 706</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(a)(2)(B)</td>
+
+  <td class='statutesatlargepage'>706</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(a)(3)</td>
+
+  <td class='statutesatlargepage'>706</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(b)(1), (2)(A)</td>
+
+  <td class='statutesatlargepage'>707, 708</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>709</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(b)(3)</td>
+
+  <td class='statutesatlargepage'>709</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(c)(1)</td>
+
+  <td class='statutesatlargepage'>709</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(c)(2)</td>
+
+  <td class='statutesatlargepage'>709</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(c)(3)</td>
+
+  <td class='statutesatlargepage'>710</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(d)(1)</td>
+
+  <td class='statutesatlargepage'>710</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(d)(2)</td>
+
+  <td class='statutesatlargepage'>710</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6103(d)(3)</td>
+
+  <td class='statutesatlargepage'>710</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6103(e)</td>
+
+  <td class='statutesatlargepage'>710</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6104</td>
+
+  <td class='statutesatlargepage'>711</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395yy&num=0&edition=prelim>1395yy</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6105(a)</td>
+
+  <td class='statutesatlargepage'>711</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6105(b)</td>
+
+  <td class='statutesatlargepage'>712</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6106</td>
+
+  <td class='statutesatlargepage'>712</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6111(a)</td>
+
+  <td class='statutesatlargepage'>713</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6111(b)</td>
+
+  <td class='statutesatlargepage'>715</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6111(c)</td>
+
+  <td class='statutesatlargepage'>716</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6112</td>
+
+  <td class='statutesatlargepage'>716</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6113(a)</td>
+
+  <td class='statutesatlargepage'>718</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6113(b)</td>
+
+  <td class='statutesatlargepage'>719</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6113(c)</td>
+
+  <td class='statutesatlargepage'>720</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7j&num=0&edition=prelim>1320a&ndash;7j nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6114</td>
+
+  <td class='statutesatlargepage'>720</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6121(a)</td>
+
+  <td class='statutesatlargepage'>720</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6121(b)</td>
+
+  <td class='statutesatlargepage'>721</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r&num=0&edition=prelim>1396r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6121(c)</td>
+
+  <td class='statutesatlargepage'>721</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3&num=0&edition=prelim>1395i&ndash;3 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6201</td>
+
+  <td class='statutesatlargepage'>721</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7l&num=0&edition=prelim>1320a&ndash;7<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(a)</td>
+
+  <td class='statutesatlargepage'>727</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320e&num=0&edition=prelim>1320e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(b)</td>
+
+  <td class='statutesatlargepage'>738</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-37&num=0&edition=prelim>299b&ndash;37</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(c)</td>
+
+  <td class='statutesatlargepage'>740</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320e-1&num=0&edition=prelim>1320e&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(d)</td>
+
+  <td class='statutesatlargepage'>741</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320e-2&num=0&edition=prelim>1320e&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(e)(1)(A)</td>
+
+  <td class='statutesatlargepage'>742</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section9511&num=0&edition=prelim>9511</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(e)(1)(B)</td>
+
+  <td class='statutesatlargepage'>743</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section9501&num=0&edition=prelim>prec. 9501</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(e)(2)(A)</td>
+
+  <td class='statutesatlargepage'>743</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4375&num=0&edition=prelim>prec. 4375</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(e)(2)(A)</td>
+
+  <td class='statutesatlargepage'>743</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4375&num=0&edition=prelim>4375</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(e)(2)(A)</td>
+
+  <td class='statutesatlargepage'>744</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4376&num=0&edition=prelim>4376</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(e)(2)(A)</td>
+
+  <td class='statutesatlargepage'>746</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4377&num=0&edition=prelim>4377</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(e)(2)(B)(i)</td>
+
+  <td class='statutesatlargepage'>746</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4371&num=0&edition=prelim>prec. 4371</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6301(e)(2)(B)(ii)</td>
+
+  <td class='statutesatlargepage'>747</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4001&num=0&edition=prelim>prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6301(f)</td>
+
+  <td class='statutesatlargepage'>747</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6302</td>
+
+  <td class='statutesatlargepage'>747</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>299b&ndash;8 nt</td>
+
+  <td class='unitedstatescodestatus'>Elim.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6401(a)</td>
+
+  <td class='statutesatlargepage'>747</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc&num=0&edition=prelim>1395cc</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6401(b)(1)</td>
+
+  <td class='statutesatlargepage'>751</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6401(b)(2)</td>
+
+  <td class='statutesatlargepage'>752</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc&num=0&edition=prelim>1395cc nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6401(b)(3)</td>
+
+  <td class='statutesatlargepage'>753</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6401(c)</td>
+
+  <td class='statutesatlargepage'>753</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397gg&num=0&edition=prelim>1397gg</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(a)</td>
+
+  <td class='statutesatlargepage'>753</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7k&num=0&edition=prelim>1320a&ndash;7k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(b)(1)</td>
+
+  <td class='statutesatlargepage'>756</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-115&num=0&edition=prelim>1395w&ndash;115</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(b)(2)</td>
+
+  <td class='statutesatlargepage'>756</td>
+
+  <td class='unitedstatescodetitle'>5</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section552a&num=0&edition=prelim>552a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(b)(3)</td>
+
+  <td class='statutesatlargepage'>756</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section405&num=0&edition=prelim>405</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(c)</td>
+
+  <td class='statutesatlargepage'>757</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(d)(1)</td>
+
+  <td class='statutesatlargepage'>757</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(d)(2)</td>
+
+  <td class='statutesatlargepage'>757</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7a&num=0&edition=prelim>1320a&ndash;7a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(e)</td>
+
+  <td class='statutesatlargepage'>759</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(f)</td>
+
+  <td class='statutesatlargepage'>759</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7b&num=0&edition=prelim>1320a&ndash;7b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(g)(1)</td>
+
+  <td class='statutesatlargepage'>759</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(g)(2)</td>
+
+  <td class='statutesatlargepage'>759</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(g)(3), (h)(1)</td>
+
+  <td class='statutesatlargepage'>759, 760</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395y&num=0&edition=prelim>1395y</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(h)(2)</td>
+
+  <td class='statutesatlargepage'>760</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(i)</td>
+
+  <td class='statutesatlargepage'>760</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i&num=0&edition=prelim>1395i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(j)(1)</td>
+
+  <td class='statutesatlargepage'>762</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ddd&num=0&edition=prelim>1395ddd</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6402(j)(2)</td>
+
+  <td class='statutesatlargepage'>762</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396u-6&num=0&edition=prelim>1396u&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6402(k)</td>
+
+  <td class='statutesatlargepage'>763</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6403(a)</td>
+
+  <td class='statutesatlargepage'>763</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7e&num=0&edition=prelim>1320a&ndash;7e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6403(b)</td>
+
+  <td class='statutesatlargepage'>764</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-2&num=0&edition=prelim>1396r&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6403(c)</td>
+
+  <td class='statutesatlargepage'>766</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7c&num=0&edition=prelim>1320a&ndash;7c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6403(d)</td>
+
+  <td class='statutesatlargepage'>766</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7e&num=0&edition=prelim>1320a&ndash;7e nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6404(a)(1)</td>
+
+  <td class='statutesatlargepage'>767</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6404(a)(2)(A)</td>
+
+  <td class='statutesatlargepage'>767</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395u&num=0&edition=prelim>1395u</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6404(a)(2)(B)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395n&num=0&edition=prelim>1395n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6404(b)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6405(a)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6405(b)(1)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6405(b)(2)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395n&num=0&edition=prelim>1395n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6405(c)</td>
+
+  <td class='statutesatlargepage'>768</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6405(d)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6406(a)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395u&num=0&edition=prelim>1395u</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6406(b)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc&num=0&edition=prelim>1395cc</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6406(c)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6406(d)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6407(a)(1)</td>
+
+  <td class='statutesatlargepage'>769</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6407(a)(2)</td>
+
+  <td class='statutesatlargepage'>770</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395n&num=0&edition=prelim>1395n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6407(b)</td>
+
+  <td class='statutesatlargepage'>770</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6407(c)</td>
+
+  <td class='statutesatlargepage'>770</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6407(d)</td>
+
+  <td class='statutesatlargepage'>770</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6408(a)</td>
+
+  <td class='statutesatlargepage'>770</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7a&num=0&edition=prelim>1320a&ndash;7a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6408(b)</td>
+
+  <td class='statutesatlargepage'>771</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27&num=0&edition=prelim>1395w&ndash;27</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6408(c)</td>
+
+  <td class='statutesatlargepage'>772</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6408(d)</td>
+
+  <td class='statutesatlargepage'>772</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6409</td>
+
+  <td class='statutesatlargepage'>772</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6410(a)</td>
+
+  <td class='statutesatlargepage'>773</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-3&num=0&edition=prelim>1395w&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6410(b)</td>
+
+  <td class='statutesatlargepage'>773</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6411(a)(1)</td>
+
+  <td class='statutesatlargepage'>773</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6411(a)(2)</td>
+
+  <td class='statutesatlargepage'>775</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6411(b)</td>
+
+  <td class='statutesatlargepage'>775</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ddd&num=0&edition=prelim>1395ddd</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6411(c)</td>
+
+  <td class='statutesatlargepage'>775</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6501&ndash;6503</td>
+
+  <td class='statutesatlargepage'>776</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6504(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>776, 777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6504(b)(2)</td>
+
+  <td class='statutesatlargepage'>777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6505</td>
+
+  <td class='statutesatlargepage'>777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6506(a)(1)</td>
+
+  <td class='statutesatlargepage'>777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6506(a)(2)</td>
+
+  <td class='statutesatlargepage'>777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6506(b)</td>
+
+  <td class='statutesatlargepage'>777</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6507</td>
+
+  <td class='statutesatlargepage'>778</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396b&num=0&edition=prelim>1396b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6508</td>
+
+  <td class='statutesatlargepage'>778</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6601(a)</td>
+
+  <td class='statutesatlargepage'>779</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1149&num=0&edition=prelim>1149</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6601(b)</td>
+
+  <td class='statutesatlargepage'>779</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1131&num=0&edition=prelim>1131</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6602</td>
+
+  <td class='statutesatlargepage'>780</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section24&num=0&edition=prelim>24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6603</td>
+
+  <td class='statutesatlargepage'>780</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-95&num=0&edition=prelim>300gg&ndash;95</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6604(a)</td>
+
+  <td class='statutesatlargepage'>780</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1150&num=0&edition=prelim>1150</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6605(a)</td>
+
+  <td class='statutesatlargepage'>780</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1151&num=0&edition=prelim>1151</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6606</td>
+
+  <td class='statutesatlargepage'>781</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1021&num=0&edition=prelim>1021</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6607</td>
+
+  <td class='statutesatlargepage'>781</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1134&num=0&edition=prelim>1134</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6701</td>
+
+  <td class='statutesatlargepage'>782</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1305&num=0&edition=prelim>1305 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6702</td>
+
+  <td class='statutesatlargepage'>782</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3a&num=0&edition=prelim>1395i&ndash;3a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>782</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397j&num=0&edition=prelim>1397j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>785</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397j-1&num=0&edition=prelim>1397j&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>786</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397k&num=0&edition=prelim>1397k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>787</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397k-1&num=0&edition=prelim>1397k&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>789</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397k-2&num=0&edition=prelim>1397k&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>790</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397k-3&num=0&edition=prelim>1397k&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>790</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397l&num=0&edition=prelim>1397<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>791</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m&num=0&edition=prelim>1397m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>794</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m-1&num=0&edition=prelim>1397m&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>796</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m-2&num=0&edition=prelim>1397m&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>796</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m-3&num=0&edition=prelim>1397m&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>797</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m-4&num=0&edition=prelim>1397m&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(1)(C)</td>
+
+  <td class='statutesatlargepage'>798</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397m-5&num=0&edition=prelim>1397m&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(a)(2)(A)</td>
+
+  <td class='statutesatlargepage'>798</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section602&num=0&edition=prelim>602</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(a)(2)(B)</td>
+
+  <td class='statutesatlargepage'>798</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section602&num=0&edition=prelim>602 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(b)(1), (2)</td>
+
+  <td class='statutesatlargepage'>798, 799</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395i-3a&num=0&edition=prelim>1395i&ndash;3a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(b)(3)</td>
+
+  <td class='statutesatlargepage'>800</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320b-25&num=0&edition=prelim>1320b&ndash;25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(1)(A)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397&num=0&edition=prelim>1397</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397&num=0&edition=prelim>1397</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397a&num=0&edition=prelim>1397a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397c&num=0&edition=prelim>1397c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397d&num=0&edition=prelim>1397d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397e&num=0&edition=prelim>1397e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(1)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397g&num=0&edition=prelim>1397g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(2)(A)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section604&num=0&edition=prelim>604</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(2)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section622&num=0&edition=prelim>622</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(2)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section671&num=0&edition=prelim>671</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(2)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section672&num=0&edition=prelim>672</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(2)(B)</td>
+
+  <td class='statutesatlargepage'>803</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section673&num=0&edition=prelim>673</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>6703(d)(3)(A)</td>
+
+  <td class='statutesatlargepage'>804</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7&num=0&edition=prelim>1320a&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>6703(d)(3)(B)</td>
+
+  <td class='statutesatlargepage'>804</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320a-7a&num=0&edition=prelim>1320a&ndash;7a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7001(a)</td>
+
+  <td class='statutesatlargepage'>804</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section201&num=0&edition=prelim>201 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(a), (b)</td>
+
+  <td class='statutesatlargepage'>804, 814</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(c)(1)</td>
+
+  <td class='statutesatlargepage'>815</td>
+
+  <td class='unitedstatescodetitle'>35</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title35-section271&num=0&edition=prelim>271</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(c)(2)</td>
+
+  <td class='statutesatlargepage'>816</td>
+
+  <td class='unitedstatescodetitle'>28</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title28-section2201&num=0&edition=prelim>2201</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(d)(1)</td>
+
+  <td class='statutesatlargepage'>816</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section355&num=0&edition=prelim>355</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(d)(2)</td>
+
+  <td class='statutesatlargepage'>816</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section355c&num=0&edition=prelim>355c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(e)</td>
+
+  <td class='statutesatlargepage'>817</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(f)(3)(A)</td>
+
+  <td class='statutesatlargepage'>818</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section379g&num=0&edition=prelim>379g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(f)(3)(B), (C)</td>
+
+  <td class='statutesatlargepage'>818, 819</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(g)(1)</td>
+
+  <td class='statutesatlargepage'>819</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(g)(2)(A)</td>
+
+  <td class='statutesatlargepage'>820</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section284m&num=0&edition=prelim>284m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7002(g)(2)(B)</td>
+
+  <td class='statutesatlargepage'>820</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section355a&num=0&edition=prelim>355a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7002(h)</td>
+
+  <td class='statutesatlargepage'>821</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7003</td>
+
+  <td class='statutesatlargepage'>821</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section262&num=0&edition=prelim>262 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7101(a)&ndash;(d)</td>
+
+  <td class='statutesatlargepage'>821&ndash;823</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256b&num=0&edition=prelim>256b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>7101(e)</td>
+
+  <td class='statutesatlargepage'>823</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256b&num=0&edition=prelim>256b nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>7102</td>
+
+  <td class='statutesatlargepage'>823</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256b&num=0&edition=prelim>256b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>8001</td>
+
+  <td class='statutesatlargepage'>828</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>201 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>8002(a)(1)</td>
+
+  <td class='statutesatlargepage'>828&ndash;846</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>300<em>ll</em> to 300<em>ll</em>&ndash;9</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>8002(a)(2), (b)</td>
+
+  <td class='statutesatlargepage'>846</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>8002(c)</td>
+
+  <td class='statutesatlargepage'>846</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>300<em>ll</em> nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>8002(d)</td>
+
+  <td class='statutesatlargepage'>847</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396p&num=0&edition=prelim>1396p nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>8002(e)</td>
+
+  <td class='statutesatlargepage'>847</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>300<em>ll</em> nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>8002(f)</td>
+
+  <td class='statutesatlargepage'>847</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>300<em>ll</em> nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9001(a)</td>
+
+  <td class='statutesatlargepage'>847</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980I&num=0&edition=prelim>4980I</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9001(b)</td>
+
+  <td class='statutesatlargepage'>853</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4971&num=0&edition=prelim>prec. 4971</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9001(c)</td>
+
+  <td class='statutesatlargepage'>853</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980I&num=0&edition=prelim>4980I nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9002(a)</td>
+
+  <td class='statutesatlargepage'>853</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6051&num=0&edition=prelim>6051</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9002(b)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6051&num=0&edition=prelim>6051 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9003(a)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section223&num=0&edition=prelim>223</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9003(b)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section220&num=0&edition=prelim>220</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9003(c)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section106&num=0&edition=prelim>106</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9003(d)(1)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section220&num=0&edition=prelim>220 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9003(d)(2)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section106&num=0&edition=prelim>106 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9004(a)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section223&num=0&edition=prelim>223</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9004(b)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section220&num=0&edition=prelim>220</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9004(c)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section220&num=0&edition=prelim>220 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9005(a)</td>
+
+  <td class='statutesatlargepage'>854</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9005(b)</td>
+
+  <td class='statutesatlargepage'>855</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9006(a), (b)</td>
+
+  <td class='statutesatlargepage'>855</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6041&num=0&edition=prelim>6041</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9006(c)</td>
+
+  <td class='statutesatlargepage'>855</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6041&num=0&edition=prelim>6041 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9007(a)</td>
+
+  <td class='statutesatlargepage'>855</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9007(b)(1)</td>
+
+  <td class='statutesatlargepage'>857</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4959&num=0&edition=prelim>4959</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9007(b)(2)</td>
+
+  <td class='statutesatlargepage'>857</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4958&num=0&edition=prelim>prec. 4958</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9007(c)</td>
+
+  <td class='statutesatlargepage'>857</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9007(d)</td>
+
+  <td class='statutesatlargepage'>857</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6033&num=0&edition=prelim>6033</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9007(e)</td>
+
+  <td class='statutesatlargepage'>858</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9007(f)</td>
+
+  <td class='statutesatlargepage'>858</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9008</td>
+
+  <td class='statutesatlargepage'>859</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-sectionnt. 4001&num=0&edition=prelim>nt. prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9008(k)</td>
+
+  <td class='statutesatlargepage'>862</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395t&num=0&edition=prelim>1395t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9009</td>
+
+  <td class='statutesatlargepage'>862</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>nt. prec. 4001</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9010</td>
+
+  <td class='statutesatlargepage'>865</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-sectionnt. 4001&num=0&edition=prelim>nt. prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9012(a)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139A&num=0&edition=prelim>139A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9012(b)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139A&num=0&edition=prelim>139A nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9013(a), (b)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section213&num=0&edition=prelim>213</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9013(c)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section56&num=0&edition=prelim>56</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9013(d)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section56&num=0&edition=prelim>56 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9014(a)</td>
+
+  <td class='statutesatlargepage'>868</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section162&num=0&edition=prelim>162</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9014(b)</td>
+
+  <td class='statutesatlargepage'>870</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section162&num=0&edition=prelim>162 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9015(a)(1)</td>
+
+  <td class='statutesatlargepage'>870</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section3101&num=0&edition=prelim>3101</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9015(a)(2)</td>
+
+  <td class='statutesatlargepage'>871</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section3102&num=0&edition=prelim>3102</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9015(b)(1)</td>
+
+  <td class='statutesatlargepage'>871</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1401&num=0&edition=prelim>1401</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9015(b)(2)(A)</td>
+
+  <td class='statutesatlargepage'>871</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section164&num=0&edition=prelim>164</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9015(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>871</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1402&num=0&edition=prelim>1402</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9015(c)</td>
+
+  <td class='statutesatlargepage'>872</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section164&num=0&edition=prelim>164 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9016(a)</td>
+
+  <td class='statutesatlargepage'>872</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section833&num=0&edition=prelim>833</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9016(b)</td>
+
+  <td class='statutesatlargepage'>872</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section833&num=0&edition=prelim>833 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9017(a)</td>
+
+  <td class='statutesatlargepage'>872</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>prec. 5000B</td>
+
+  <td class='unitedstatescodestatus'>Elim.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9017(a)</td>
+
+  <td class='statutesatlargepage'>872</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>5000B</td>
+
+  <td class='unitedstatescodestatus'>Elim.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9017(b)</td>
+
+  <td class='statutesatlargepage'>873</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>prec. 4001</td>
+
+  <td class='unitedstatescodestatus'>Elim.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9017(c)</td>
+
+  <td class='statutesatlargepage'>873</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>5000B nt</td>
+
+  <td class='unitedstatescodestatus'>Elim.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9021(a)</td>
+
+  <td class='statutesatlargepage'>873</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139D&num=0&edition=prelim>139D</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9021(b)</td>
+
+  <td class='statutesatlargepage'>874</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section101&num=0&edition=prelim>prec. 101</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9021(c)</td>
+
+  <td class='statutesatlargepage'>874</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139D&num=0&edition=prelim>139D nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9021(d)</td>
+
+  <td class='statutesatlargepage'>874</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139D&num=0&edition=prelim>139D nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9022(a)</td>
+
+  <td class='statutesatlargepage'>874</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9022(b)</td>
+
+  <td class='statutesatlargepage'>876</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9023(a)</td>
+
+  <td class='statutesatlargepage'>877</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section48D&num=0&edition=prelim>48D</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9023(b)</td>
+
+  <td class='statutesatlargepage'>880</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section46&num=0&edition=prelim>46</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9023(c)(1)</td>
+
+  <td class='statutesatlargepage'>880</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section49&num=0&edition=prelim>49</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9023(c)(2)</td>
+
+  <td class='statutesatlargepage'>880</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section280C&num=0&edition=prelim>280C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9023(d)</td>
+
+  <td class='statutesatlargepage'>881</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section46&num=0&edition=prelim>prec. 46</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>9023(e)</td>
+
+  <td class='statutesatlargepage'>881</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section48D&num=0&edition=prelim>48D nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>9023(f)</td>
+
+  <td class='statutesatlargepage'>883</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section46&num=0&edition=prelim>46 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10101(a)</td>
+
+  <td class='statutesatlargepage'>883</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-11&num=0&edition=prelim>300gg&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10101(b)</td>
+
+  <td class='statutesatlargepage'>884</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-15&num=0&edition=prelim>300gg&ndash;15</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10101(c)</td>
+
+  <td class='statutesatlargepage'>884</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-15a&num=0&edition=prelim>300gg&ndash;15a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10101(d)</td>
+
+  <td class='statutesatlargepage'>884</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-16&num=0&edition=prelim>300gg&ndash;16</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10101(e)</td>
+
+  <td class='statutesatlargepage'>884</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-17&num=0&edition=prelim>300gg&ndash;17</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10101(f)</td>
+
+  <td class='statutesatlargepage'>885</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-18&num=0&edition=prelim>300gg&ndash;18</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10101(g)</td>
+
+  <td class='statutesatlargepage'>887</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-19&num=0&edition=prelim>300gg&ndash;19</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10101(h)</td>
+
+  <td class='statutesatlargepage'>888</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-19a&num=0&edition=prelim>300gg&ndash;19a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10101(i)</td>
+
+  <td class='statutesatlargepage'>891</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-94&num=0&edition=prelim>300gg&ndash;94</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10102(a)</td>
+
+  <td class='statutesatlargepage'>892</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18002&num=0&edition=prelim>18002</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10102(b)</td>
+
+  <td class='statutesatlargepage'>892</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18003&num=0&edition=prelim>18003</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10103(a)</td>
+
+  <td class='statutesatlargepage'>892</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg&num=0&edition=prelim>300gg</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10103(b)</td>
+
+  <td class='statutesatlargepage'>892</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-7&num=0&edition=prelim>300gg&ndash;7</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10103(c)</td>
+
+  <td class='statutesatlargepage'>892</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-8&num=0&edition=prelim>300gg&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10103(d)</td>
+
+  <td class='statutesatlargepage'>895</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18011&num=0&edition=prelim>18011</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10103(e)</td>
+
+  <td class='statutesatlargepage'>895</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg&num=0&edition=prelim>300gg nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10103(f)(1)</td>
+
+  <td class='statutesatlargepage'>895</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg&num=0&edition=prelim>300gg nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10103(f)(2)</td>
+
+  <td class='statutesatlargepage'>895</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18013&num=0&edition=prelim>18013</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(a)</td>
+
+  <td class='statutesatlargepage'>896</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18021&num=0&edition=prelim>18021</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(b)</td>
+
+  <td class='statutesatlargepage'>896</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18022&num=0&edition=prelim>18022</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(c)</td>
+
+  <td class='statutesatlargepage'>896</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18023&num=0&edition=prelim>18023</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(d)</td>
+
+  <td class='statutesatlargepage'>900</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18024&num=0&edition=prelim>18024</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(e)&ndash;(h)</td>
+
+  <td class='statutesatlargepage'>900, 901</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18031&num=0&edition=prelim>18031</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(i)</td>
+
+  <td class='statutesatlargepage'>901</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18032&num=0&edition=prelim>18032</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(j)(1)</td>
+
+  <td class='statutesatlargepage'>901</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18033&num=0&edition=prelim>18033 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(j)(2)</td>
+
+  <td class='statutesatlargepage'>901</td>
+
+  <td class='unitedstatescodetitle'>31</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title31-section3730&num=0&edition=prelim>3730</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(k)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18033&num=0&edition=prelim>18033</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(<em>l</em>)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18042&num=0&edition=prelim>18042</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(m)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>18043</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(n)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18044&num=0&edition=prelim>18044</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(<em>o</em>)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18051&num=0&edition=prelim>18051</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(p)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18053&num=0&edition=prelim>18053</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10104(q)</td>
+
+  <td class='statutesatlargepage'>902</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18054&num=0&edition=prelim>18054</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10104(r)</td>
+
+  <td class='statutesatlargepage'>906</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18061&num=0&edition=prelim>18061</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10105(a)&ndash;(c)</td>
+
+  <td class='statutesatlargepage'>906</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section36B&num=0&edition=prelim>36B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10105(d)</td>
+
+  <td class='statutesatlargepage'>906</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6211&num=0&edition=prelim>6211</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10105(e)(1), (2)</td>
+
+  <td class='statutesatlargepage'>906</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section45R&num=0&edition=prelim>45R</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10105(e)(3)</td>
+
+  <td class='statutesatlargepage'>906</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section280C&num=0&edition=prelim>280C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10105(e)(4)</td>
+
+  <td class='statutesatlargepage'>907</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section38&num=0&edition=prelim>38 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10105(e)(5)</td>
+
+  <td class='statutesatlargepage'>907</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section45R&num=0&edition=prelim>45R nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10106(a)</td>
+
+  <td class='statutesatlargepage'>907</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18091&num=0&edition=prelim>18091</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10106(b)&ndash;(d)</td>
+
+  <td class='statutesatlargepage'>909, 910</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000A&num=0&edition=prelim>5000A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10106(e)&ndash;(f)(2)</td>
+
+  <td class='statutesatlargepage'>910</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10106(f)(3)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10106(g)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6056&num=0&edition=prelim>6056</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(a)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-21&num=0&edition=prelim>300gg&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section9815&num=0&edition=prelim>9815</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section1185d&num=0&edition=prelim>1185d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-1&num=0&edition=prelim>300gg&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-2&num=0&edition=prelim>300gg&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-3&num=0&edition=prelim>300gg&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-9&num=0&edition=prelim>300gg&ndash;9</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-11&num=0&edition=prelim>300gg&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-12&num=0&edition=prelim>300gg&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-21&num=0&edition=prelim>300gg&ndash;21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-22&num=0&edition=prelim>300gg&ndash;22</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-23&num=0&edition=prelim>300gg&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-25&num=0&edition=prelim>300gg&ndash;25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-26&num=0&edition=prelim>300gg&ndash;26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-27&num=0&edition=prelim>300gg&ndash;27</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-28&num=0&edition=prelim>300gg&ndash;28</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-62&num=0&edition=prelim>300gg&ndash;62</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300gg-91&num=0&edition=prelim>300gg&ndash;91</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10107(b)(1)</td>
+
+  <td class='statutesatlargepage'>911</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18120&num=0&edition=prelim>18120</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10107(b)(2)</td>
+
+  <td class='statutesatlargepage'>912</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18119&num=0&edition=prelim>18119</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(a)&ndash;(e)</td>
+
+  <td class='statutesatlargepage'>912, 913</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>18101</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(f)(1)</td>
+
+  <td class='statutesatlargepage'>913</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>139D</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(f)(2)</td>
+
+  <td class='statutesatlargepage'>913</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section101&num=0&edition=prelim>prec. 101</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(f)(3)</td>
+
+  <td class='statutesatlargepage'>913</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section139D&num=0&edition=prelim>139D nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(g)(1)</td>
+
+  <td class='statutesatlargepage'>913</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section162&num=0&edition=prelim>162</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(g)(2)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section162&num=0&edition=prelim>162 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(h)(1)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section36B&num=0&edition=prelim>36B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(h)(2)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section36B&num=0&edition=prelim>36B nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(i)(1)(A)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(i)(1)(B)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980H&num=0&edition=prelim>4980H nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(i)(2)</td>
+
+  <td class='statutesatlargepage'>914</td>
+
+  <td class='unitedstatescodetitle'>29</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title29-section218b&num=0&edition=prelim>218b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(j)(1)&ndash;(3)(D)</td>
+
+  <td class='statutesatlargepage'>914, 915</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6056&num=0&edition=prelim>6056</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(j)(3)(E), (F)</td>
+
+  <td class='statutesatlargepage'>915</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6724&num=0&edition=prelim>6724</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10108(j)(3)(G)</td>
+
+  <td class='statutesatlargepage'>915</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6055&num=0&edition=prelim>prec. 6055</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10108(j)(4)</td>
+
+  <td class='statutesatlargepage'>915</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6056&num=0&edition=prelim>6056 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10109(a)</td>
+
+  <td class='statutesatlargepage'>915</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d-2&num=0&edition=prelim>1320d&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10109(b), (c)</td>
+
+  <td class='statutesatlargepage'>916</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320d-2&num=0&edition=prelim>1320d&ndash;2 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10201(a)(1), (2)</td>
+
+  <td class='statutesatlargepage'>917</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10201(a)(3)</td>
+
+  <td class='statutesatlargepage'>918</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10201(b)</td>
+
+  <td class='statutesatlargepage'>918</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396a&num=0&edition=prelim>1396a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10201(c)</td>
+
+  <td class='statutesatlargepage'>918</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10201(d)</td>
+
+  <td class='statutesatlargepage'>919</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1308&num=0&edition=prelim>1308</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10201(e)</td>
+
+  <td class='statutesatlargepage'>920</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396r-4&num=0&edition=prelim>1396r&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10201(f)</td>
+
+  <td class='statutesatlargepage'>922</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1396r&ndash;4 nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10201(g)</td>
+
+  <td class='statutesatlargepage'>922</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ee&num=0&edition=prelim>1397ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10201(h)</td>
+
+  <td class='statutesatlargepage'>922</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section713&num=0&edition=prelim>713</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10201(i)</td>
+
+  <td class='statutesatlargepage'>922</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315&num=0&edition=prelim>1315</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10202</td>
+
+  <td class='statutesatlargepage'>923</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396d&num=0&edition=prelim>1396d nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10203(a)</td>
+
+  <td class='statutesatlargepage'>927</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18031&num=0&edition=prelim>18031</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10203(b)</td>
+
+  <td class='statutesatlargepage'>927</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e&num=0&edition=prelim>1396e nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10203(b)(1)</td>
+
+  <td class='statutesatlargepage'>927</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e&num=0&edition=prelim>1396e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10203(b)(2)</td>
+
+  <td class='statutesatlargepage'>927</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e-1&num=0&edition=prelim>1396e&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10203(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>927</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396e-1&num=0&edition=prelim>1396e&ndash;1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10203(b)(3), (4), (c)</td>
+
+  <td class='statutesatlargepage'>927, 928</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ee&num=0&edition=prelim>1397ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10203(d)(1)&ndash;(2)(B)</td>
+
+  <td class='statutesatlargepage'>928&ndash;930</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397dd&num=0&edition=prelim>1397dd</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10203(d)(2)(C)</td>
+
+  <td class='statutesatlargepage'>930</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397ee&num=0&edition=prelim>1397ee</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10203(d)(2)(D)</td>
+
+  <td class='statutesatlargepage'>930</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397jj&num=0&edition=prelim>1397jj</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10203(d)(2)(E)</td>
+
+  <td class='statutesatlargepage'>931</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397mm&num=0&edition=prelim>1397mm</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10211</td>
+
+  <td class='statutesatlargepage'>931</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18201&num=0&edition=prelim>18201</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10212</td>
+
+  <td class='statutesatlargepage'>932</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18202&num=0&edition=prelim>18202</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10213</td>
+
+  <td class='statutesatlargepage'>932</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18203&num=0&edition=prelim>18203</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10214</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18204&num=0&edition=prelim>18204</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1601&num=0&edition=prelim>1601 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680o&num=0&edition=prelim>1680<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1616p</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621h&num=0&edition=prelim>1621h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621j&num=0&edition=prelim>1621j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621o&num=0&edition=prelim>1621<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1621w</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1638a</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1647</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660b&num=0&edition=prelim>1660b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1660d</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1663</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1675</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621c&num=0&edition=prelim>1621c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621l&num=0&edition=prelim>1621<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1638b&num=0&edition=prelim>1638b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1601&num=0&edition=prelim>1601</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1602&num=0&edition=prelim>1602</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1603&num=0&edition=prelim>1603</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1616l&num=0&edition=prelim>1616<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1616p&num=0&edition=prelim>1616p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1616q&num=0&edition=prelim>1616q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1616r</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621&num=0&edition=prelim>1621</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621a&num=0&edition=prelim>1621a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621c&num=0&edition=prelim>1621c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621d&num=0&edition=prelim>1621d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1680k</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680l&num=0&edition=prelim>1680<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621e&num=0&edition=prelim>1621e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621f&num=0&edition=prelim>1621f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621h&num=0&edition=prelim>1621h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621k&num=0&edition=prelim>1621k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621l&num=0&edition=prelim>1621<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621m&num=0&edition=prelim>1621m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621o&num=0&edition=prelim>1621<em>o</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621p&num=0&edition=prelim>1621p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621q&num=0&edition=prelim>1621q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621t&num=0&edition=prelim>1621t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1616r&num=0&edition=prelim>1616r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1615&num=0&edition=prelim>1615</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621u&num=0&edition=prelim>1621u</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621v&num=0&edition=prelim>1621v</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1621y&num=0&edition=prelim>1621y</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1631&num=0&edition=prelim>1631</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1637&num=0&edition=prelim>1637</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1638a&num=0&edition=prelim>1638a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1638e&num=0&edition=prelim>1638e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1638f&num=0&edition=prelim>1638f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1638g&num=0&edition=prelim>1638g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1641&num=0&edition=prelim>1641</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1642&num=0&edition=prelim>1642</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1644&num=0&edition=prelim>1644</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1645&num=0&edition=prelim>1645</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1647&num=0&edition=prelim>1647</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1647a&num=0&edition=prelim>1647a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1647b&num=0&edition=prelim>1647b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1647c&num=0&edition=prelim>1647c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1647d&num=0&edition=prelim>1647d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1659&num=0&edition=prelim>1659</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660b&num=0&edition=prelim>1660b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660d&num=0&edition=prelim>1660d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1652&num=0&edition=prelim>1652</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660e&num=0&edition=prelim>1660e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660f&num=0&edition=prelim>1660f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660g&num=0&edition=prelim>1660g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1660h&num=0&edition=prelim>1660h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1661&num=0&edition=prelim>1661</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1663&num=0&edition=prelim>1663</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1663a&num=0&edition=prelim>1663a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665&num=0&edition=prelim>1665</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665a&num=0&edition=prelim>1665a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665b&num=0&edition=prelim>1665b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665c&num=0&edition=prelim>1665c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665d&num=0&edition=prelim>1665d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665e&num=0&edition=prelim>1665e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665f&num=0&edition=prelim>1665f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665g&num=0&edition=prelim>1665g</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665h&num=0&edition=prelim>1665h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665i&num=0&edition=prelim>1665i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665j&num=0&edition=prelim>1665j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665k&num=0&edition=prelim>1665k</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665l&num=0&edition=prelim>1665<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665m&num=0&edition=prelim>1665m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1665n&num=0&edition=prelim>1665n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667&num=0&edition=prelim>1667</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667a&num=0&edition=prelim>1667a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667b&num=0&edition=prelim>1667b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667c&num=0&edition=prelim>1667c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667d&num=0&edition=prelim>1667d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1667e&num=0&edition=prelim>1667e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1675&num=0&edition=prelim>1675</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1678&num=0&edition=prelim>1678</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1678</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1678a&num=0&edition=prelim>1678a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1679&num=0&edition=prelim>1679</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1679</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680b&num=0&edition=prelim>1680b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680c&num=0&edition=prelim>1680c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680p&num=0&edition=prelim>1680p</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680q&num=0&edition=prelim>1680q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680r&num=0&edition=prelim>1680r</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680s&num=0&edition=prelim>1680s</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680t&num=0&edition=prelim>1680t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680u&num=0&edition=prelim>1680u</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1680v&num=0&edition=prelim>1680v</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395qq&num=0&edition=prelim>1395qq</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11705&num=0&edition=prelim>11705</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11706&num=0&edition=prelim>11706</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11709&num=0&edition=prelim>11709</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11705&num=0&edition=prelim>11705</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11705&num=0&edition=prelim>11705 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(a)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section11711&num=0&edition=prelim>11711</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(b)(1)</td>
+
+  <td class='statutesatlargepage'>935</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1616l&num=0&edition=prelim>1616<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(b)(2)</td>
+
+  <td class='statutesatlargepage'>936</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'>1616r</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(b)(3)</td>
+
+  <td class='statutesatlargepage'>936</td>
+
+  <td class='unitedstatescodetitle'>25</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title25-section1676&num=0&edition=prelim>1676</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10221(b)(4)</td>
+
+  <td class='statutesatlargepage'>936</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10221(b)(4)</td>
+
+  <td class='statutesatlargepage'>936</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395qq&num=0&edition=prelim>1395qq</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10302</td>
+
+  <td class='statutesatlargepage'>937</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j&num=0&edition=prelim>280j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10303(a)</td>
+
+  <td class='statutesatlargepage'>937</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-31&num=0&edition=prelim>299b&ndash;31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10303(b)</td>
+
+  <td class='statutesatlargepage'>938</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa-1&num=0&edition=prelim>1395aaa&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10303(c)</td>
+
+  <td class='statutesatlargepage'>938</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299&num=0&edition=prelim>299 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10304</td>
+
+  <td class='statutesatlargepage'>938</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa&num=0&edition=prelim>1395aaa</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10304</td>
+
+  <td class='statutesatlargepage'>938</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa-1&num=0&edition=prelim>1395aaa&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10305</td>
+
+  <td class='statutesatlargepage'>938</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280j-1&num=0&edition=prelim>280j&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10306</td>
+
+  <td class='statutesatlargepage'>939</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1315a&num=0&edition=prelim>1315a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10307</td>
+
+  <td class='statutesatlargepage'>940</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395jjj&num=0&edition=prelim>1395jjj</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10308(a), (b)(1)</td>
+
+  <td class='statutesatlargepage'>941, 942</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc-4&num=0&edition=prelim>1395cc&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10308(b)(2)</td>
+
+  <td class='statutesatlargepage'>942</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc-5&num=0&edition=prelim>1395cc&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10309</td>
+
+  <td class='statutesatlargepage'>942</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10310</td>
+
+  <td class='statutesatlargepage'>942</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10311(a)</td>
+
+  <td class='statutesatlargepage'>942</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10311(b)</td>
+
+  <td class='statutesatlargepage'>943</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10311(c)</td>
+
+  <td class='statutesatlargepage'>943</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10312(a)</td>
+
+  <td class='statutesatlargepage'>943</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10312(b)</td>
+
+  <td class='statutesatlargepage'>943</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10313</td>
+
+  <td class='statutesatlargepage'>943</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10314</td>
+
+  <td class='statutesatlargepage'>944</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10315(a)</td>
+
+  <td class='statutesatlargepage'>944</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10315(b)</td>
+
+  <td class='statutesatlargepage'>944</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10316</td>
+
+  <td class='statutesatlargepage'>946</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10317</td>
+
+  <td class='statutesatlargepage'>947</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10317</td>
+
+  <td class='statutesatlargepage'>947</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10318</td>
+
+  <td class='statutesatlargepage'>948</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-23&num=0&edition=prelim>1395w&ndash;23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10319(a)&ndash;(c)</td>
+
+  <td class='statutesatlargepage'>948</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10319(d)</td>
+
+  <td class='statutesatlargepage'>949</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395fff&num=0&edition=prelim>1395fff</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10319(e)</td>
+
+  <td class='statutesatlargepage'>949</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10319(f)</td>
+
+  <td class='statutesatlargepage'>949</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10319(g)</td>
+
+  <td class='statutesatlargepage'>949</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10320(a), (b)</td>
+
+  <td class='statutesatlargepage'>949, 952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk&num=0&edition=prelim>1395kkk</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10320(b)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section207&num=0&edition=prelim>207</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10320(b)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-6&num=0&edition=prelim>1395b&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10320(b)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk&num=0&edition=prelim>1395kkk nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10320(b)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk-1&num=0&edition=prelim>1395kkk&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10320(c)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kkk&num=0&edition=prelim>1395kkk nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10321</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256a-1&num=0&edition=prelim>256a&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10322(a)</td>
+
+  <td class='statutesatlargepage'>952</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10322(b)</td>
+
+  <td class='statutesatlargepage'>954</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395aaa&num=0&edition=prelim>1395aaa</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10323(a)</td>
+
+  <td class='statutesatlargepage'>954</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395rr-1&num=0&edition=prelim>1395rr&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10323(b)</td>
+
+  <td class='statutesatlargepage'>957</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1397h&num=0&edition=prelim>1397h</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10324(a)</td>
+
+  <td class='statutesatlargepage'>959</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10324(b)</td>
+
+  <td class='statutesatlargepage'>960</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10324(c)</td>
+
+  <td class='statutesatlargepage'>960</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10326</td>
+
+  <td class='statutesatlargepage'>961</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395b-1&num=0&edition=prelim>1395b&ndash;1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10327(a)</td>
+
+  <td class='statutesatlargepage'>962</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10327(b)</td>
+
+  <td class='statutesatlargepage'>963</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10327(c)(1)</td>
+
+  <td class='statutesatlargepage'>964</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27a&num=0&edition=prelim>1395w&ndash;27a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10327(c)(2)</td>
+
+  <td class='statutesatlargepage'>964</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-27a&num=0&edition=prelim>1395w&ndash;27a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10328(a)</td>
+
+  <td class='statutesatlargepage'>964</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10328(b)</td>
+
+  <td class='statutesatlargepage'>965</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-104&num=0&edition=prelim>1395w&ndash;104 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10331</td>
+
+  <td class='statutesatlargepage'>966</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-5&num=0&edition=prelim>1395w&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10332(a)</td>
+
+  <td class='statutesatlargepage'>968</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kk&num=0&edition=prelim>1395kk</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10332(b)</td>
+
+  <td class='statutesatlargepage'>970</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395kk&num=0&edition=prelim>1395kk nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10333</td>
+
+  <td class='statutesatlargepage'>970</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256i&num=0&edition=prelim>256i</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(a)(1)</td>
+
+  <td class='statutesatlargepage'>971</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6&num=0&edition=prelim>300u&ndash;6</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(a)(2)</td>
+
+  <td class='statutesatlargepage'>971</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6&num=0&edition=prelim>300u&ndash;6 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(a)(3)</td>
+
+  <td class='statutesatlargepage'>972</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6&num=0&edition=prelim>300u&ndash;6 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(b)(1)</td>
+
+  <td class='statutesatlargepage'>972</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6a&num=0&edition=prelim>300u&ndash;6a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(b)(2)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6a&num=0&edition=prelim>300u&ndash;6a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(b)(3)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-6a&num=0&edition=prelim>300u&ndash;6a nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(1)(D)(i)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t&num=0&edition=prelim>285t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(1)(D)(i)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-1&num=0&edition=prelim>285t&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(1)(D)(i)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-2&num=0&edition=prelim>285t&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(1)(D)(i)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-3&num=0&edition=prelim>285t&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(1)(D)(ii)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t&num=0&edition=prelim>285t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(1)(D)(iii)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t&num=0&edition=prelim>285t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(1)(D)(iii)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-1&num=0&edition=prelim>285t&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(1)(D)(iii)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-2&num=0&edition=prelim>285t&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(1)(D)(iii)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t-3&num=0&edition=prelim>285t&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(2)</td>
+
+  <td class='statutesatlargepage'>973</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285t&num=0&edition=prelim>285t</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10334(c)(3)(A)</td>
+
+  <td class='statutesatlargepage'>974</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section281&num=0&edition=prelim>281</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10334(c)(3)(B)</td>
+
+  <td class='statutesatlargepage'>974</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299a-1&num=0&edition=prelim>299a&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10335</td>
+
+  <td class='statutesatlargepage'>974</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10401(a)</td>
+
+  <td class='statutesatlargepage'>974</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-10&num=0&edition=prelim>300u&ndash;10</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10401(b)</td>
+
+  <td class='statutesatlargepage'>974</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-11&num=0&edition=prelim>300u&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10401(c)</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-12&num=0&edition=prelim>300u&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10402(a)</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280h-5&num=0&edition=prelim>280h&ndash;5</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10402(b)</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10403</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300u-13&num=0&edition=prelim>300u&ndash;13</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10404</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l&num=0&edition=prelim>280<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10406</td>
+
+  <td class='statutesatlargepage'>975</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10407</td>
+
+  <td class='statutesatlargepage'>976</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section247b-9a&num=0&edition=prelim>247b&ndash;9a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10408</td>
+
+  <td class='statutesatlargepage'>977</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280l&num=0&edition=prelim>280<em>l</em> nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10409(a)</td>
+
+  <td class='statutesatlargepage'>978</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section201&num=0&edition=prelim>201 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10409(b)</td>
+
+  <td class='statutesatlargepage'>978</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section282&num=0&edition=prelim>282</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10409(c)</td>
+
+  <td class='statutesatlargepage'>978</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section290b&num=0&edition=prelim>290b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10409(d)</td>
+
+  <td class='statutesatlargepage'>978</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section287a&num=0&edition=prelim>287a</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10410(a)</td>
+
+  <td class='statutesatlargepage'>984</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section201&num=0&edition=prelim>201 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10410(b)</td>
+
+  <td class='statutesatlargepage'>984</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section290bb-33&num=0&edition=prelim>290bb&ndash;33</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10411(a)</td>
+
+  <td class='statutesatlargepage'>988</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section201&num=0&edition=prelim>201 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10411(b)(1)</td>
+
+  <td class='statutesatlargepage'>988</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-13&num=0&edition=prelim>280g&ndash;13</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10411(b)(2)</td>
+
+  <td class='statutesatlargepage'>989</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section285b-8&num=0&edition=prelim>285b&ndash;8</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10412</td>
+
+  <td class='statutesatlargepage'>990</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section244&num=0&edition=prelim>244</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10413(a)</td>
+
+  <td class='statutesatlargepage'>990</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section201&num=0&edition=prelim>201 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10413(b)</td>
+
+  <td class='statutesatlargepage'>991</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280m&num=0&edition=prelim>280m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(a)</td>
+
+  <td class='statutesatlargepage'>993</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section294q&num=0&edition=prelim>294q</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(c)</td>
+
+  <td class='statutesatlargepage'>994</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-11&num=0&edition=prelim>280g&ndash;11</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(d)</td>
+
+  <td class='statutesatlargepage'>995</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293b&num=0&edition=prelim>293b</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(e)</td>
+
+  <td class='statutesatlargepage'>995</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section296j-1&num=0&edition=prelim>296j&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(f)(1), (2)</td>
+
+  <td class='statutesatlargepage'>996</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-12&num=0&edition=prelim>280g&ndash;12</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(f)(3)</td>
+
+  <td class='statutesatlargepage'>996</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-34&num=0&edition=prelim>299b&ndash;34</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(f)(4)</td>
+
+  <td class='statutesatlargepage'>996</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section299b-35&num=0&edition=prelim>299b&ndash;35</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(g)</td>
+
+  <td class='statutesatlargepage'>996</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-14&num=0&edition=prelim>280g&ndash;14</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(h)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395w-4&num=0&edition=prelim>1395w&ndash;4</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(i)(1)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(i)(1)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(i)(1)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'>1395x nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(i)(2)(A)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(i)(2)(B)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395x&num=0&edition=prelim>1395x nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(i)(3)(A)</td>
+
+  <td class='statutesatlargepage'>997</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395m&num=0&edition=prelim>1395m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(i)(3)(B), (C)</td>
+
+  <td class='statutesatlargepage'>998, 999</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395l&num=0&edition=prelim>1395<em>l</em></a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(j)</td>
+
+  <td class='statutesatlargepage'>999</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395ww&num=0&edition=prelim>1395ww nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(k)</td>
+
+  <td class='statutesatlargepage'>999</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b-1&num=0&edition=prelim>254b&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(<em>l</em>)(2)</td>
+
+  <td class='statutesatlargepage'>1000</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section293m&num=0&edition=prelim>293m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(m)(1)</td>
+
+  <td class='statutesatlargepage'>1001</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295c&num=0&edition=prelim>295c</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(m)(2)</td>
+
+  <td class='statutesatlargepage'>1002</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section295e&num=0&edition=prelim>295e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(n)(1), (2)</td>
+
+  <td class='statutesatlargepage'>1002, 1003</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254d&num=0&edition=prelim>254d</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(n)(3)</td>
+
+  <td class='statutesatlargepage'>1003</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254j&num=0&edition=prelim>254j</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10501(n)(4)</td>
+
+  <td class='statutesatlargepage'>1003</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254l-1&num=0&edition=prelim>254<em>l</em>&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10501(n)(5)</td>
+
+  <td class='statutesatlargepage'>1003</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254m&num=0&edition=prelim>254m</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10503</td>
+
+  <td class='statutesatlargepage'>1004</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section254b-2&num=0&edition=prelim>254b&ndash;2</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10504</td>
+
+  <td class='statutesatlargepage'>1004</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section256&num=0&edition=prelim>256 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10601(a)</td>
+
+  <td class='statutesatlargepage'>1005</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10601(b)</td>
+
+  <td class='statutesatlargepage'>1005</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395nn&num=0&edition=prelim>1395nn nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10602</td>
+
+  <td class='statutesatlargepage'>1005</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1320e&num=0&edition=prelim>1320e</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10603</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395cc&num=0&edition=prelim>1395cc</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10604</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10604</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395n&num=0&edition=prelim>1395n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10605(a)</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395f&num=0&edition=prelim>1395f</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10605(b)</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1395n&num=0&edition=prelim>1395n</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10606(a)</td>
+
+  <td class='statutesatlargepage'>1006</td>
+
+  <td class='unitedstatescodetitle'>28</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title28-section994&num=0&edition=prelim>994 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10606(b)</td>
+
+  <td class='statutesatlargepage'>1008</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section1347&num=0&edition=prelim>1347</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10606(c)</td>
+
+  <td class='statutesatlargepage'>1008</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section24&num=0&edition=prelim>24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10606(d)(1)</td>
+
+  <td class='statutesatlargepage'>1008</td>
+
+  <td class='unitedstatescodetitle'>18</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section1510&num=0&edition=prelim>1510</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10606(d)(2)</td>
+
+  <td class='statutesatlargepage'>1008</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1997a-1&num=0&edition=prelim>1997a&ndash;1</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10607</td>
+
+  <td class='statutesatlargepage'>1009</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section280g-15&num=0&edition=prelim>280g&ndash;15</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10608(a)</td>
+
+  <td class='statutesatlargepage'>1014</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section233&num=0&edition=prelim>233</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10608(b)</td>
+
+  <td class='statutesatlargepage'>1014</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section233&num=0&edition=prelim>233 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10609</td>
+
+  <td class='statutesatlargepage'>1014</td>
+
+  <td class='unitedstatescodetitle'>21</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title21-section355&num=0&edition=prelim>355</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10801(a)(1), (2)</td>
+
+  <td class='statutesatlargepage'>1015</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section300ll-2, 300ll-3&num=0&edition=prelim>300<em>ll</em>&ndash;2, 300<em>ll</em>&ndash;3</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10801(c)</td>
+
+  <td class='statutesatlargepage'>1015</td>
+
+  <td class='unitedstatescodetitle'>42</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1396p&num=0&edition=prelim>1396p nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10901(a), (b)</td>
+
+  <td class='statutesatlargepage'>1015, 1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980I&num=0&edition=prelim>4980I</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10901(c)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4980I&num=0&edition=prelim>4980I nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10902(a)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10902(b)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section125&num=0&edition=prelim>125 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10903(a)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10903(b)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section501&num=0&edition=prelim>501 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10904(a)</td>
+
+  <td class='statutesatlargepage'>1016</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>nt. prec. 4001</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10904(b)</td>
+
+  <td class='statutesatlargepage'>1017</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-sectionnt. 4001&num=0&edition=prelim>nt. prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10905(a)&ndash;(f)</td>
+
+  <td class='statutesatlargepage'>1017&ndash;1019</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-sectionnt. 4001&num=0&edition=prelim>nt. prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10905(g)</td>
+
+  <td class='statutesatlargepage'>1019</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-sectionnt. 4001&num=0&edition=prelim>nt. prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10906(a)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section3101&num=0&edition=prelim>3101</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10906(b)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1401&num=0&edition=prelim>1401</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10906(c)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1401&num=0&edition=prelim>1401 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10907(a)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4001&num=0&edition=prelim>prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10907(a)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000B&num=0&edition=prelim>prec. 5000B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10907(a)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'>5000B, 5000B nt</td>
+
+  <td class='unitedstatescodestatus'>Rep.</td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10907(b)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000B&num=0&edition=prelim>prec. 5000B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10907(b)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000B&num=0&edition=prelim>5000B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10907(c)</td>
+
+  <td class='statutesatlargepage'>1020</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section4001&num=0&edition=prelim>prec. 4001</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10907(d)</td>
+
+  <td class='statutesatlargepage'>1021</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section5000B&num=0&edition=prelim>5000B nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10908(a)</td>
+
+  <td class='statutesatlargepage'>1021</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section108&num=0&edition=prelim>108</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10908(b)</td>
+
+  <td class='statutesatlargepage'>1021</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section108&num=0&edition=prelim>108 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(a)(1)</td>
+
+  <td class='statutesatlargepage'>1021</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section23&num=0&edition=prelim>23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(a)(2)</td>
+
+  <td class='statutesatlargepage'>1022</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section137&num=0&edition=prelim>137</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(1)</td>
+
+  <td class='statutesatlargepage'>1022</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section23&num=0&edition=prelim>23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(A)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section24&num=0&edition=prelim>24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(B)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25&num=0&edition=prelim>25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(C)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25A&num=0&edition=prelim>25A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(D)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25B&num=0&edition=prelim>25B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(E)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section26&num=0&edition=prelim>26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(F)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30&num=0&edition=prelim>30</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(G)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30B&num=0&edition=prelim>30B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(H)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30D&num=0&edition=prelim>30D</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(I)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section23&num=0&edition=prelim>23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(J)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section137&num=0&edition=prelim>137</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(K)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section904&num=0&edition=prelim>904</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(L)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1016&num=0&edition=prelim>1016</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(M)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1400C&num=0&edition=prelim>1400C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(N)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6211&num=0&edition=prelim>6211</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(O)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section21&num=0&edition=prelim>prec. 21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(b)(2)(P)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>31</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title31-section1324&num=0&edition=prelim>1324</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(b)(2)(Q)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section31&num=0&edition=prelim>prec. 31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1&num=0&edition=prelim>1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section21&num=0&edition=prelim>prec. 21</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section23&num=0&edition=prelim>23</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section24&num=0&edition=prelim>24</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25&num=0&edition=prelim>25</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25A&num=0&edition=prelim>25A</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section25B&num=0&edition=prelim>25B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section26&num=0&edition=prelim>26</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30&num=0&edition=prelim>30</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30B&num=0&edition=prelim>30B</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section30D&num=0&edition=prelim>30D</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section31&num=0&edition=prelim>prec. 31</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section137&num=0&edition=prelim>137</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section904&num=0&edition=prelim>904</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1016&num=0&edition=prelim>1016</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1400C&num=0&edition=prelim>1400C</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_odd'>
+
+  <td class='actsection'>10909(c)</td>
+
+  <td class='statutesatlargepage'>1023</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section6211&num=0&edition=prelim>6211</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+ <tr class='table3row_even'>
+
+  <td class='actsection'>10909(d)</td>
+
+  <td class='statutesatlargepage'>1024</td>
+
+  <td class='unitedstatescodetitle'>26</td>
+
+  <td class='unitedstatescodesection'><a href=http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title26-section1&num=0&edition=prelim>1 nt</a></td>
+
+  <td class='unitedstatescodestatus'></td>
+
+ </tr>
+
+<!-- field-end:documentdata -->
+
+</table>
+
+
+
+
+
+</div>
+
+
+
+                    </div>
+                </div>
+                <div style="clear: both; width: 0px; height: 0px;">             
+                </div>
+            </div>
+    <div id="footer">
+        <div style="margin-left: 2px; margin-top: 2px; width: 161px; height: 28px; overflow: visible; float: left;">
+            <form target="_blank" action="http://twitter.com/uscode">
+                <input type="image" src="/javax.faces.resource/u35.png.xhtml?ln=images" style="width: 160px; height: 27px;" />
+            </form>
+        </div>
+        <div style="margin-top: 9px; margin-right: 10px; width: 310px; height: 16px; font-family: Arial; float: right; word-wrap: break-word;" id="u34">
+            <div style="text-align: right;">
+                <span class="footer"><a href="/about_office.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959">About the Office</a> 
+                          <a href="/privacy_policy.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959">Privacy Policy</a>     
+                      <a href="/sitemap.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959">Sitemap</a>
+                </span>
+            </div>
+        </div>
+    </div>
+        </div><span id="resizeWindow" class="debugCode">
+<form id="form1" name="form1" method="post" action="/static.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959" enctype="application/x-www-form-urlencoded">
+<input type="hidden" name="form1" value="form1" />
+<input id="winTop" type="hidden" name="winTop" value="0" /><input id="left" type="hidden" name="left" value="0" /><input id="width" type="hidden" name="width" value="0" /><input id="height" type="hidden" name="height" value="0" /><input id="submitBtn" type="submit" name="submitBtn" value="change value" onclick="jsf.ajax.request(this, event, {execute:'@form', render: '@form'}); return false;" /><input id="refreshBtn" type="submit" name="refreshBtn" value="refresh value" onclick="jsf.ajax.request(this, event, {render: '@form'}); return false;" /><input type="hidden" name="javax.faces.ViewState" id="javax.faces.ViewState" value="H4sIAAAAAAAAAN1Zb2gcxxUfnXSypcpCll03JthWY9lYrrOnPydHthKqkyVXomdH+FRRJxBltDt3t9LezmR29m5l18b50ITUFAqJCQGHFlpKPqSfki/50lJCCQRiiKEUGgKhDYR8SFOCQ0v7oX0zu3e7t3dXKQWfIAca5m7+/d57v/fmzdPrn6Ekczjau47LWHOFaWkL2ClewCy568+/f/vA0+93osR51GtRbJzHuqB8EfWIIidOkVqGx747g+RntLIbWtlPCbRrfdU0xMSUy9G+J7NqYwvbBe3xtXWii+mf3fnhzwecESuBkMdgRcJ9Bl1HndBLMliy/8kmax743b9zH2988G51TUdtTaLM0bCc72l5rBNHI2ViC22JOiJjGMt0xSSVefnT32++9Yc/DbzxltyCo+ONS87REqM29HKbjiAltei3hal7K3dW+v1FhxoXReYe23j5bfPDg3f8ud8MFapGfUGyP+25+EDp2mtKDlD7vnBWhnO8mTUd4T1799Ar7+BXO1HHIupyzCvEV1OlS7ZODLteRa3lBBZkAaxCeA6XCb/87huPvXj7vQsJlMiiHt3CjnMRl4hAg0q/KanfVE5w0y5MZ1GvA2sMtYdAB/wZJk3lCDexZV7BaxaZ9hgrS733O7IdEGi+OZIfLNZ0OdxMq1JKYhOeMTAThIe2rO47CXtpjmsHO3Nig1AbptCKomStrmHH1EHcTQtYSIi4pIYJZ0CFw60QPe4K5goUfjwG4oTUu87R5NbSLHHKCBeb3yebzhI3y6Ct6n6Dyuz9IXXnbbcUHWQC7ccC9L3mCuIsF7HIcJIjQgndH7GwUgKT7f6gL9Dheo3I1oKlWmZpKbs4P+cBfO2rwY9Ck6ccFqg3hKcORoF3dyvvln8d8udh4OBkCzxmiVnaHMlj1xLn/R+HM4xZm8t0g9hfvnbq8u2Z9Zk+qY7Kd9C3UxBIqMthi1Se40IJQEKPUmCF5kljw5FzV24+f88DYwnU4wjjEsnPCjs0XK0XiQkA8OEWAImlLePCBSKK1Jj3GJzvmNQOdNHRp4x40NckTI3Pw4P3hmf/+ozwfXxfbV4445c//knuiyfuPlr18CNVHE12WwRlfXjp+lTf5Rc/7wvMMFo5jh46etUR2DYwl9ICtW2daIxTEMTJ6AJWXkMoHl0DT/7N3ZVPPj109Xu1SCmahS1/F+WMjHmVp9FTEUuAmzILmB32fFsMzUyePjWeHsJqcdWJH9sG2oc8xaeJSnpbskWcaIWahrLrpLQPkz4riRBcMY+EJo9eIrLbXc8I2dmztafJ5kA8HsnmoJr1YF3IkJ0j2/Be5TPKuMf/p1vJ5qQXEe9MRCjWhpMF6naITm2jdlKXr+69Cs/4xNmJs34v3QJZJ8ShdKs4BLcPMPQctQU2gThbRaNuuLHEolFLThQfFm1BCoQP/uUXv/rHs89PJeQdmSxjyyXgjwPhvItuaY3w516/degbL310s+oMu0CWwaosYzVh5IG5qtbHxpuS6r7qXw2OtAyIRYKN5gGxZpipmCxdYpORlmacbCr5xGT7JQ85310kZqEo4pi7K6a9TFlLUUZjotQGzsQ1YpF8w+57QMHuapGWSNa0N9ps7hF0pKm5JaYGY0eJGzdfOPJIy5E4QXo5ycssvu4ubfDlM819WWLTFqCB1KIEwXzWFYLaWzm04qSMMe5ayRTStgrSVFuCuEBj20kqdW6yMKFsT8w3fP4rZZxp2412q63ShUQcb0nRdGzE10h6x8Lxw+joNrKi+oDsYz69M4H0zZiqx2IKTVbgW7EhwqpJX79Uyqi/IePsqg2cbnoZpncgDZDNyXrUcW+pDbSO9M3lGZ+o4d7dTnluqIwdROrUsQhz2/Gxr12guxFJ3dM7FAF89nS63Ip7eYBrB6JpE1bHA1NI3ng6l8yb3GlI25Jy0vYZVOZopEmJkBP/oq/VR9R7+It//vpE5wtnjyWCxKX3/6SefPzPtihCCFzQ1p08ZFScaHNEtzDHwiyTJjWyHw3fIJ/fyj6qqnh7bJrhheqQQA+q97+XIlYqXluYzqJ+ECoyHVB1fMtjCl0qeI/PodGjV21cNgtYPr0XIJez4KVhEEE4PNZIDvDqghjn4LorUL55YuRa9JXlFzXr3ucVgvQtstqhmbHRU2Ojp4esSAnhq4EICgr3R4wOsd3ycBvlBQ4PtXpYyxr3JUobqpssZOKJrdYOy84FzP4TfOBlnUVJB5gKKfvxgGdqeQozZpm6wp6ClF/qLifnTXvRMNCnwsCAr8+9DTUfwJQu0LJWpK5DNNfRqUFCYI7mEMz1oixq168L5OtIoCQwXKd23iycNy0iS9vy+L1ZtFvFjBVsBd97/KJG+IN6iAR9GStVVz6xUimAlFKQUj6klH+Cy31xhayDU1ADIPRKFmhcetXJsJGF2Lp/R0SUpUWVVTVUtPwK44aramAiqEGuqk1WLervsLown5mrBZruuri967rsHROojwfPl2WQEmjTVaamUUeN+xHh3/TqCzWzlFoE2+8N8Rt/vP2vvwGdnqgWaphSmub9F0oL8KJ8GgAA" autocomplete="off" />
+</form>
+<form id="formStdRef" name="formStdRef" method="post" action="/static.xhtml;jsessionid=629C2B019419362DC648DD591D4BD959" enctype="application/x-www-form-urlencoded">
+<input type="hidden" name="formStdRef" value="formStdRef" />
+<input id="first" type="hidden" name="first" value="" /><input id="second" type="hidden" name="second" value="" /><input id="type" type="hidden" name="type" value="" /><input id="url" type="hidden" name="url" value="" /><input id="stdRefBtn" type="submit" name="stdRefBtn" value="open std ref value" onclick="jsf.ajax.request(this, event, {execute:'@form', render: '@form'}); return false;" /><input type="hidden" name="javax.faces.ViewState" id="javax.faces.ViewState" value="H4sIAAAAAAAAAN1Zb2gcxxUfnXSypcpCll03JthWY9lYrrOnPydHthKqkyVXomdH+FRRJxBltDt3t9LezmR29m5l18b50ITUFAqJCQGHFlpKPqSfki/50lJCCQRiiKEUGgKhDYR8SFOCQ0v7oX0zu3e7t3dXKQWfIAca5m7+/d57v/fmzdPrn6Ekczjau47LWHOFaWkL2ClewCy568+/f/vA0+93osR51GtRbJzHuqB8EfWIIidOkVqGx747g+RntLIbWtlPCbRrfdU0xMSUy9G+J7NqYwvbBe3xtXWii+mf3fnhzwecESuBkMdgRcJ9Bl1HndBLMliy/8kmax743b9zH2988G51TUdtTaLM0bCc72l5rBNHI2ViC22JOiJjGMt0xSSVefnT32++9Yc/DbzxltyCo+ONS87REqM29HKbjiAltei3hal7K3dW+v1FhxoXReYe23j5bfPDg3f8ud8MFapGfUGyP+25+EDp2mtKDlD7vnBWhnO8mTUd4T1799Ar7+BXO1HHIupyzCvEV1OlS7ZODLteRa3lBBZkAaxCeA6XCb/87huPvXj7vQsJlMiiHt3CjnMRl4hAg0q/KanfVE5w0y5MZ1GvA2sMtYdAB/wZJk3lCDexZV7BaxaZ9hgrS733O7IdEGi+OZIfLNZ0OdxMq1JKYhOeMTAThIe2rO47CXtpjmsHO3Nig1AbptCKomStrmHH1EHcTQtYSIi4pIYJZ0CFw60QPe4K5goUfjwG4oTUu87R5NbSLHHKCBeb3yebzhI3y6Ct6n6Dyuz9IXXnbbcUHWQC7ccC9L3mCuIsF7HIcJIjQgndH7GwUgKT7f6gL9Dheo3I1oKlWmZpKbs4P+cBfO2rwY9Ck6ccFqg3hKcORoF3dyvvln8d8udh4OBkCzxmiVnaHMlj1xLn/R+HM4xZm8t0g9hfvnbq8u2Z9Zk+qY7Kd9C3UxBIqMthi1Se40IJQEKPUmCF5kljw5FzV24+f88DYwnU4wjjEsnPCjs0XK0XiQkA8OEWAImlLePCBSKK1Jj3GJzvmNQOdNHRp4x40NckTI3Pw4P3hmf/+ozwfXxfbV4445c//knuiyfuPlr18CNVHE12WwRlfXjp+lTf5Rc/7wvMMFo5jh46etUR2DYwl9ICtW2daIxTEMTJ6AJWXkMoHl0DT/7N3ZVPPj109Xu1SCmahS1/F+WMjHmVp9FTEUuAmzILmB32fFsMzUyePjWeHsJqcdWJH9sG2oc8xaeJSnpbskWcaIWahrLrpLQPkz4riRBcMY+EJo9eIrLbXc8I2dmztafJ5kA8HsnmoJr1YF3IkJ0j2/Be5TPKuMf/p1vJ5qQXEe9MRCjWhpMF6naITm2jdlKXr+69Cs/4xNmJs34v3QJZJ8ShdKs4BLcPMPQctQU2gThbRaNuuLHEolFLThQfFm1BCoQP/uUXv/rHs89PJeQdmSxjyyXgjwPhvItuaY3w516/degbL310s+oMu0CWwaosYzVh5IG5qtbHxpuS6r7qXw2OtAyIRYKN5gGxZpipmCxdYpORlmacbCr5xGT7JQ85310kZqEo4pi7K6a9TFlLUUZjotQGzsQ1YpF8w+57QMHuapGWSNa0N9ps7hF0pKm5JaYGY0eJGzdfOPJIy5E4QXo5ycssvu4ubfDlM819WWLTFqCB1KIEwXzWFYLaWzm04qSMMe5ayRTStgrSVFuCuEBj20kqdW6yMKFsT8w3fP4rZZxp2412q63ShUQcb0nRdGzE10h6x8Lxw+joNrKi+oDsYz69M4H0zZiqx2IKTVbgW7EhwqpJX79Uyqi/IePsqg2cbnoZpncgDZDNyXrUcW+pDbSO9M3lGZ+o4d7dTnluqIwdROrUsQhz2/Gxr12guxFJ3dM7FAF89nS63Ip7eYBrB6JpE1bHA1NI3ng6l8yb3GlI25Jy0vYZVOZopEmJkBP/oq/VR9R7+It//vpE5wtnjyWCxKX3/6SefPzPtihCCFzQ1p08ZFScaHNEtzDHwiyTJjWyHw3fIJ/fyj6qqnh7bJrhheqQQA+q97+XIlYqXluYzqJ+ECoyHVB1fMtjCl0qeI/PodGjV21cNgtYPr0XIJez4KVhEEE4PNZIDvDqghjn4LorUL55YuRa9JXlFzXr3ucVgvQtstqhmbHRU2Ojp4esSAnhq4EICgr3R4wOsd3ycBvlBQ4PtXpYyxr3JUobqpssZOKJrdYOy84FzP4TfOBlnUVJB5gKKfvxgGdqeQozZpm6wp6ClF/qLifnTXvRMNCnwsCAr8+9DTUfwJQu0LJWpK5DNNfRqUFCYI7mEMz1oixq168L5OtIoCQwXKd23iycNy0iS9vy+L1ZtFvFjBVsBd97/KJG+IN6iAR9GStVVz6xUimAlFKQUj6klH+Cy31xhayDU1ADIPRKFmhcetXJsJGF2Lp/R0SUpUWVVTVUtPwK44aramAiqEGuqk1WLervsLown5mrBZruuri967rsHROojwfPl2WQEmjTVaamUUeN+xHh3/TqCzWzlFoE2+8N8Rt/vP2vvwGdnqgWaphSmub9F0oL8KJ8GgAA" autocomplete="off" />
+</form></span></body>
+</html>

--- a/table3/ParseTable.py
+++ b/table3/ParseTable.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Feb 19 19:24:15 2014
+The purpose of this script is to parse the mapping of Public Law sections to U.S. Code sections.
+This file parses HTML files such as http://uscode.house.gov/table3/111_148.htm
+The output is a list of references, currently printing to standard output.
+@author: Pablo, @williampli
+"""
+
+from __future__ import division
+from bs4 import BeautifulSoup
+import re
+import sys
+
+def parseTable(f):
+   
+    soup = BeautifulSoup(f)
+    f.close()
+    
+    t = soup.find('table')
+    t3 = t.find_all('tr')
+
+
+    sections = []
+    for row in t3:
+        cols = map(lambda x: x.get_text(),row.find_all("td"))
+        if len(cols) > 4:
+            sections.append((cols[2],cols[3]))
+    return sections
+                
+                
+
+if __name__ == "__main__":
+    args = sys.argv
+    if len(args) != 2:
+        print 'Usage: python ParseTable.py inputHTMLfile.htm'
+        sys.exit()
+    filename = sys.argv[1]
+    f = file(filename,'r')
+    sections = parseTable(f)
+    print sections

--- a/table3/README
+++ b/table3/README
@@ -1,0 +1,26 @@
+This subdirectory contains the tools for extracting information from "Table III". As noted on http://uscode.house.gov/table3/table3explanation.htm, Table III contains information about the classification of public laws to the United States Code. This information is also available in PDF form on the U.S. Code website, but the HTML pages seemed easier to parse.
+
+The key files are:
+
+* table3_scraper.py 
+* ParseTable.py
+
+table3_scraper.py does the following:
+
+1. Parse http://uscode.house.gov/table3/table3years.htm to extract links to year-specific pages with laws, e.g. http://uscode.house.gov/table3/year1950.htm  
+2. Parse each of the year-specific pages for extract links to a page for each law, e.g. http://uscode.house.gov/table3/1950_654.htm
+3. Download the full HTML of the year-specific page.
+
+The years downloaded are specified in a set called `years` in the script. To limit the number of files downloaded, you can set the `LIMIT_SUBSUBRELEASES` to `True` and `LIMIT` to the desired total number of files.
+
+---
+
+ParseTable.py does the following:
+
+1. Take, as input, a downloaded law-specific HTML file from the final step of table3_scraper. The command is `python ParseTable.py [inputHTMLfile]
+2. Extract the mapping of public law sections to U.S. Code sections.
+
+
+
+
+

--- a/table3/requirements.txt
+++ b/table3/requirements.txt
@@ -1,0 +1,5 @@
+simplejson
+lxml
+httplib2
+simplejson
+bs4

--- a/table3/table3_scraper.py
+++ b/table3/table3_scraper.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+import os, sys 
+import httplib2
+from lxml import etree
+from StringIO import StringIO
+import re
+import simplejson
+
+# Table Three Scraper http://uscode.house.gov/table3/table3years.htm
+# The scrapers grab the URLs for each year from 1789 to 2011, go one directory down to grab the directory, then go one directory below and grab the whole page.  THIS CODE TAKES A WHILE TO RUN.  It may be better to tweak just for the years you want.  Also, could use some refactoring, e.g. merge some of the functions.
+
+# This script downloads files into the current directory
+
+# GLOBAL VARIABLES
+
+# Specify the years you want in a set
+years = { 1950 }
+
+# for testing purposes, the number of files downloaded can be limited.
+LIMIT_SUBSUBRELEASES = False
+LIMIT = 5
+
+def mainscraper(content): #function to parse Table 3 website
+	doc = etree.parse(StringIO(content), parser=etree.HTMLParser())
+	releases = []
+	subreleases = []
+	for element in doc.xpath('//div[@class="alltable3years"]'):   #Could also use "alltable3statutesatlargevolumes"
+		for d_element in element.xpath('span'):
+			text = d_element.xpath('a')[0].text
+			unitext = unicode(text).encode(sys.stdout.encoding, 'replace')
+			for m_element in d_element.xpath('a'):
+				addy = m_element.attrib['href']
+				year = addy.replace( 'year', '' )
+				year = year.replace( '.htm', '' )
+				if int( year ) in set( years ): 
+					url = "http://uscode.house.gov/table3/" + addy
+				        #print unitext, url
+				        #releases += [(unitext, url)]
+					subreleases += add_subrelease(url)
+					#return subreleases
+				else:
+					pass
+	return subreleases #releases, subreleases
+
+def subscraper(content): #function to parse Table 3 website
+	doc = etree.parse(StringIO(content), parser=etree.HTMLParser())
+	subsubreleases = []	
+	releases = []
+	for element in doc.xpath('//div[@class="yearmaster"]'):   #Could also use "statutesatlargevolumemasterhead"
+		for d_element in element.xpath('span'):
+			text = d_element.xpath('a')[0].text
+			unitext = unicode(text).encode(sys.stdout.encoding, 'replace')
+			for m_element in d_element.xpath('a'):
+				addy = m_element.attrib['href']
+				url = "http://uscode.house.gov/table3/" + addy
+				print addy
+				#print text, url
+				#releases += [(text, url)]
+				subsubreleases.append( add_subsubrelease(url) )
+				if LIMIT_SUBSUBRELEASES and len( subsubreleases ) == LIMIT:
+					return subsubreleases
+
+
+	return	subsubreleases
+
+def add_release(url): #function grab main page data
+	http = httplib2.Http('/tmp/httpcache')
+	response, content = http.request(url)
+	if response.status != 200:
+	    sys.stderr.write('Error, returned status: %s\n' % response.status)
+	    sys.exit(1) #bomb out, non-zero return indicates error
+	#print content
+	return mainscraper(content)
+	
+def add_subrelease(url): #function to grab sub page data
+	http = httplib2.Http('/tmp/httpcache')
+	response, content = http.request(url)
+	if response.status != 200:
+	    sys.stderr.write('Error, returned status: %s\n' % response.status)
+	    sys.exit(1) #bomb out, non-zero return indicates error
+	#print content
+	return subscraper(content)
+
+def add_subsubrelease(url): #function to grab sub, sub page data
+	http = httplib2.Http('/tmp/httpcache')
+	response, content = http.request(url)
+	if response.status != 200:
+	    sys.stderr.write('Error, returned status: %s\n' % response.status)
+	    sys.exit(1) #bomb out, non-zero return indicates error
+	# print content
+	return url, content
+
+def main():
+	dataset = []
+	x = add_release("http://uscode.house.gov/table3/table3years.htm") #Could also use "/alltable3statutesatlargevolumes.html"
+	for filename, html_string in x:
+		final_pagename = filename.split('/')[-1]
+		with open( final_pagename, 'w' ) as f:
+			f.write( html_string )
+		sys.stderr.write( "Wrote %s\n" % ( final_pagename ) )
+		
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
As discussed in https://github.com/sunlightlabs/crosslaws/pull/21, this moves @wpli's Table 3 parser into this project. It has its own README and `requirements.txt`.

/cc @apendleton @alexengler

It'd be quite neat to produce some data that cross-linked the existing output of this project (the JSON "spine" of the Code) with the legislative history of codification.
